### PR TITLE
Set index latest when passing index prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,7 @@ const SwipeableViews = React.createClass({
     if (typeof index === 'number' && index !== this.props.index) {
       this.setState({
         index: index,
+        indexLatest: index,
       });
     }
   },


### PR DESCRIPTION
We forgot one thing. Need to set indexLatest when using the index prop. You can see the bug if you remove the height on the tab example and make one of the tabs taller.