### PR TITLE
Fix flexbox styling in Safari

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const styles = {
     overflowX: 'hidden',
   },
   container: {
-    display: 'flex',
+    display: '-webkit-box; display: flex',
   },
   slide: {
     width: '100%',


### PR DESCRIPTION
  It seems like `display: 'flex'` still doesn't work in Safari
And can be fixed by adding `display: '-webkit-box'` according to this trick: https://css-tricks.com/using-flexbox/

But inline style in react didn't support same key with different value, https://github.com/facebook/react/issues/2020, hence this weird hack. (This approach has also been used in material-ui: https://github.com/callemall/material-ui/pull/1226/files)
