### PR TITLE
add `onSwitching` callback on slide switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.sublime-project
 *.sublime-workspace
 
+# WebStorm
+.idea
+
 # npm
 /node_modules
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,13 @@ This is useful when you want to prohibit the user from changing slides.
 This is useful when you want to change the default slide shown.
 Or when you have tabs linked to each slide.
 
-- **onChangeIndex** *Function(index)* - This is callback prop. It's call by the
+- **onChangeIndex** *Function(index, fromIndex )* - This is callback prop. It's call by the
 component when the shown slide change after a swipe made by the user.
 This is useful when you have tabs linked to each slide.
+
+- **onSwitching** *Function(index)* - This is callback prop. It's called by the
+component when the slide switching.
+This is useful when you want to implement something corresponding to the current slide position.
 
 - **resitance** *Boolean, default=false* - If true, it will add bounds effect on the edges.
 

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,13 @@ const SwipeableViews = React.createClass({
     onChangeIndex: React.PropTypes.func,
 
     /**
+     * This is callback prop. It's called by the
+     * component when the slide switching.
+     * This is useful when you want to implement something corresponding to the current slide position.
+     */
+    onSwitching: React.PropTypes.func,
+
+    /**
      * If true, it will add bounds effect on the edges.
      */
     resistance: React.PropTypes.bool,
@@ -147,6 +154,8 @@ const SwipeableViews = React.createClass({
       }
     }
 
+    this.props.onSwitching && this.props.onSwitching( index );
+
     this.setState({
       isDragging: true,
       index: index,
@@ -189,8 +198,10 @@ const SwipeableViews = React.createClass({
       isDragging: false,
     });
 
+    this.props.onSwitching && this.props.onSwitching( indexNew );
+
     if (this.props.onChangeIndex && indexNew !== this.startIndex) {
-      this.props.onChangeIndex(indexNew);
+      this.props.onChangeIndex(indexNew, this.startIndex);
     }
   },
   getHeightSlide(index) {

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,9 @@ const SwipeableViews = React.createClass({
       }
     }
 
-    this.props.onSwitching && this.props.onSwitching( index );
+    if (this.props.onSwitching) {
+      this.props.onSwitching(index);
+    }
 
     this.setState({
       isDragging: true,
@@ -198,7 +200,9 @@ const SwipeableViews = React.createClass({
       isDragging: false,
     });
 
-    this.props.onSwitching && this.props.onSwitching( indexNew );
+    if (this.props.onSwitching) {
+      this.props.onSwitching(indexNew);
+    }
 
     if (this.props.onChangeIndex && indexNew !== this.startIndex) {
       this.props.onChangeIndex(indexNew, this.startIndex);


### PR DESCRIPTION
1、update `.gitignore` to ignore webstorm configuration files
2、add `onSwitching` callback on slide switching
3、add a second parameter `fromIndex` for `onChangeIndex` so that we know which index the slide came from.
4、update README