### PR TITLE
[Core] Add support for v15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0",
     "react-motion": "^0.4.0"
   },
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -319,9 +319,15 @@ class SwipeableViews extends React.Component {
       updateHeight = false;
     }
 
-    const slideStyleObj = Object.assign({}, styles.slide, slideStyle);
-
     const childrenToRender = React.Children.map(children, (child, index2) => {
+      const slideTransform = {
+        position: 'absolute',
+        top: 0,
+        overflow: 'hidden',
+        transform: `translateX(${index2 * 100}%)`,
+      };
+      const slideStyleObj = Object.assign({}, styles.slide, slideStyle, slideTransform);
+
       if (isFirstRender && index2 > 0) {
         return null;
       }


### PR DESCRIPTION
On React v15, `childrenToRender` elements were no longer rendering properly; they were instead stacked like normal divs, [breaking all functionality](https://github.com/oliviertassinari/react-swipeable-views/issues/49). This is a fix I arrived at by poking around inspecting the children elements, and manually adding transforms to them.

Tested this within my project and using the README's demo code. Also, tested for backwards compatibility with React v0.0.14, and for that's worth it works there, too.