### PR TITLE
Update for React Native 0.25

### DIFF
--- a/src/index.native.animated.js
+++ b/src/index.native.animated.js
@@ -4,7 +4,7 @@
  * I'm keeping the two versions here until we figured out.
  */
 
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 
 import {
   Animated,

--- a/src/index.native.animated.js
+++ b/src/index.native.animated.js
@@ -4,9 +4,10 @@
  * I'm keeping the two versions here until we figured out.
  */
 
-import React, {
+import React, { Component } from 'react';
+
+import {
   Animated,
-  Component,
   Dimensions,
   PanResponder,
   StyleSheet,

--- a/src/index.native.scroll.js
+++ b/src/index.native.scroll.js
@@ -4,7 +4,7 @@
  * I'm keeping the two versions here until we figured out.
  */
 
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 
 import {
   StyleSheet,

--- a/src/index.native.scroll.js
+++ b/src/index.native.scroll.js
@@ -4,7 +4,9 @@
  * I'm keeping the two versions here until we figured out.
  */
 
-import React, {
+import React, { Component } from 'react';
+
+import {
   StyleSheet,
   View,
   ScrollView,
@@ -30,7 +32,7 @@ const styles = StyleSheet.create({
   },
 });
 
-class SwipeableViews extends React.Component {
+class SwipeableViews extends Component {
   static propTypes = {
     /**
      * Use this property to provide your slides.


### PR DESCRIPTION
Requiring React API from react-native is now deprecated in 0.25.