### PR TITLE
increasing onMoveShouldSetPanResponder threshold for swipe

### DIFF
--- a/src/index.native.animated.js
+++ b/src/index.native.animated.js
@@ -121,7 +121,7 @@ class SwipeableViews extends Component {
     this.panResponder = PanResponder.create({
       // Claim responder if it's a horizontal pan
       onMoveShouldSetPanResponder: (event, gestureState) => {
-        return Math.abs(gestureState.dx) > Math.abs(gestureState.dy);
+        return Math.abs(gestureState.dx) > Math.abs(gestureState.dy) && Math.abs(gestureState.dx) > 3;
       },
       onPanResponderRelease: this.handleTouchEnd,
       onPanResponderTerminate: this.handleTouchEnd,


### PR DESCRIPTION
a movement of greater than 3 in the x direction prevents swipe
from taking precedence over tap events