### PR TITLE
[virtualize] Fix fast swipe backward

### DIFF
--- a/src/virtualize.js
+++ b/src/virtualize.js
@@ -132,7 +132,12 @@ export default function virtualize(MyComponent) {
       }
 
       this.setState(nextState, () => {
-        this.setWindowTimer();
+        // We are going backward, but reached first rendered item, let's render previous right away, with no timer
+        if (indexDiff < 0 && index > 0 && indexContainer === 0) {
+          this.setWindow();
+        } else {
+          this.setWindowTimer();
+        }
       });
     }
 

--- a/src/virtualize.js
+++ b/src/virtualize.js
@@ -134,6 +134,10 @@ export default function virtualize(MyComponent) {
       this.setState(nextState, () => {
         // We are going backward, but reached first rendered item, let's render previous right away, with no timer
         if (indexDiff < 0 && index > 0 && indexContainer === 0) {
+          if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = null;
+          }
           this.setWindow();
         } else {
           this.setWindowTimer();


### PR DESCRIPTION
The problem when using virtualize HOC is when fast and continuously swiping back and reaching the edge of rendered slides. Then user may think that there are no more slides, because they are not rendered until user stops swiping and animation ends (well, actually after a 500ms timeout).

Rendering previous items right away when going backward and reaching the edge if fixing this issue.

I understand that this may kill the ongoing animation in this particular use-case, but I think it's more important to show user the content with some choppy animation, than to show a beautiful animation with no content.

To overcome this limitation of having content rendered "real-time" and have uninterrupted animations at the same time, I think slides should have absolute positioning. This way, new slides can be rendered and visually positioned at the left or right, without replacing existing DOM nodes that are currently animating.
