### PR TITLE
[AutoPlay] Ensure autoplay is stopped if the autoplay property is changed

### DIFF
--- a/src/autoPlay.js
+++ b/src/autoPlay.js
@@ -111,6 +111,7 @@ export default function autoPlay(MyComponent) {
 
       if (!autoplay) {
         clearInterval(this.timer);
+        return;
       }
 
       const indexLatest = this.state.index;

--- a/src/autoPlay.js
+++ b/src/autoPlay.js
@@ -102,11 +102,16 @@ export default function autoPlay(MyComponent) {
 
     handleInterval = () => {
       const {
+        autoplay,
         children,
         direction,
         onChangeIndex,
         slideCount,
       } = this.props;
+
+      if (!autoplay) {
+        clearInterval(this.timer);
+      }
 
       const indexLatest = this.state.index;
       let indexNew = indexLatest;


### PR DESCRIPTION
This pull request ensures that if the `autoplay` property is changed during the interval, the next slide will not transition. I need this feature as I need to support hovering the Swipeable Views pauses the slides.