### PR TITLE
bug fix:when swiped, the component's props.index will not changed,but…

### DIFF
--- a/src/SwipeableViews.js
+++ b/src/SwipeableViews.js
@@ -243,7 +243,7 @@ class SwipeableViews extends Component {
       index,
     } = nextProps;
 
-    if (typeof index === 'number' && index !== this.props.index) {
+    if (typeof index === 'number' && index !== this.state.indexCurrent) {
       if (process.env.NODE_ENV !== 'production') {
         checkIndexBounds(nextProps);
       }


### PR DESCRIPTION
… state.currendIndex is changed,this bug cause view not updated as expected:   
for example, 
   1.set view's props.index to 3 
   2.scroll to 2
   3. set props.index to 3 again
 result: the view will be  in page 2  instead of scrolling to 3
so nextProps.index should be compared to state.indexCurrent