### PR TITLE
[HOC] Add the missing second argument of onChangeIndex to virtualize.

### DIFF
--- a/src/virtualize.js
+++ b/src/virtualize.js
@@ -111,7 +111,7 @@ export default function virtualize(MyComponent) {
       }
 
       if (onChangeIndex) {
-        onChangeIndex(index);
+        onChangeIndex(index, indexLatest);
       } else {
         this.setIndex(index, indexContainer, indexDiff);
       }

--- a/src/virtualize.spec.js
+++ b/src/virtualize.spec.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import {assert} from 'chai';
 import {shallow} from 'enzyme';
+import {spy} from 'sinon';
 import virtualize from './virtualize';
 
 const Empty = () => <div />;
@@ -225,6 +226,23 @@ describe('virtualize', () => {
         indexStart: -3,
         indexStop: 9,
       });
+    });
+  });
+
+  describe('prop: onChangeIndex', () => {
+    it('should be called with the right arguments', () => {
+      const wrapper = shallow(
+        <VirtualizeSwipeableViews slideRenderer={slideRenderer} />
+      );
+      const handleChangeIndex = spy();
+      wrapper.setProps({
+        onChangeIndex: handleChangeIndex,
+      });
+      wrapper.find(Empty).simulate('changeIndex', 1, 0);
+      assert.deepEqual(handleChangeIndex.args, [
+        [1, 0],
+      ]);
+      assert.strictEqual(wrapper.state().index, 0, 'should not update the state index');
     });
   });
 });


### PR DESCRIPTION
@oliviertassinari I stumbled upon #138 in the `virtualize` HOC. Second argument of `onChangeIndex` is missing here too: https://github.com/oliviertassinari/react-swipeable-views/blob/master/src/virtualize.js#L114

This PR (including tests) should fix it for `virtualize` like #140 fixed it for `autoPlay` and `bindKeyboard `.