### PR TITLE
Check if the child item are there before calling the `key` property

### DIFF
--- a/src/utils/getDisplaySameSlide.js
+++ b/src/utils/getDisplaySameSlide.js
@@ -4,7 +4,7 @@ const getDisplaySameSlide = (props, nextProps) => {
   let displaySameSlide = false;
 
   if (props.children.length && nextProps.children.length) {
-    const oldKey = props.children[props.index].key;
+    const oldKey = props.children[props.index] ? props.children[props.index].key : null;
 
     if (oldKey !== null) {
       const newKey = nextProps.children[nextProps.index].key;


### PR DESCRIPTION
I got this issue when the item got removed.

![image](https://cloud.githubusercontent.com/assets/30276/21071331/0bd8f2b8-bed8-11e6-99ef-3c076bd670fc.png)
