### PR TITLE
add support for a 'slideClassName' prop

### DIFF
--- a/src/SwipeableViews.js
+++ b/src/SwipeableViews.js
@@ -252,15 +252,15 @@ class SwipeableViews extends Component {
      */
     resistance: PropTypes.bool,
     /**
-     * This is the inlined style that will be applied
-     * on the slide component.
-     */
-    slideStyle: PropTypes.object,
-    /**
      * This is the className that will be applied
      * on the slide component.
      */
     slideClassName: PropTypes.string,
+    /**
+     * This is the inlined style that will be applied
+     * on the slide component.
+     */
+    slideStyle: PropTypes.object,
     /**
      * This is the config given to react-motion for the spring.
      * This is useful to change the dynamic of the transition.

--- a/src/SwipeableViews.js
+++ b/src/SwipeableViews.js
@@ -257,6 +257,11 @@ class SwipeableViews extends Component {
      */
     slideStyle: PropTypes.object,
     /**
+     * This is the className that will be applied
+     * on the slide component.
+     */
+    slideClassName: PropTypes.string,
+    /**
      * This is the config given to react-motion for the spring.
      * This is useful to change the dynamic of the transition.
      */
@@ -604,6 +609,7 @@ class SwipeableViews extends Component {
       onTransitionEnd, // eslint-disable-line no-unused-vars
       resistance, // eslint-disable-line no-unused-vars
       slideStyle,
+      slideClassName,
       springConfig,
       style,
       threshold, // eslint-disable-line no-unused-vars
@@ -676,6 +682,7 @@ class SwipeableViews extends Component {
         <div
           ref={ref}
           style={slideStyleObj}
+          className={slideClassName}
           aria-hidden={hidden}
           role="option"
         >

--- a/src/SwipeableViews.spec.js
+++ b/src/SwipeableViews.spec.js
@@ -484,7 +484,7 @@ describe('SwipeableViews', () => {
 
   describe('prop: slideClassName', () => {
     it('should apply a className prop to every rendered slide component', () => {
-      const Slide = () => <div />
+      const Slide = () => <div />;
       const classNameToApply = 'someclassname';
       const wrapper = mount(
         <SwipeableViews slideClassName={classNameToApply}>
@@ -494,7 +494,8 @@ describe('SwipeableViews', () => {
       );
 
       assert.strictEqual(wrapper.find(Slide)
-        .everyWhere(slide => (slide.parent().prop('className') === classNameToApply)), true, 'should apply the className prop');
+        .everyWhere((slide) => slide.parent().prop('className') === classNameToApply),
+        true, 'should apply the className prop');
     });
   });
 });

--- a/src/SwipeableViews.spec.js
+++ b/src/SwipeableViews.spec.js
@@ -481,4 +481,20 @@ describe('SwipeableViews', () => {
       assert.strictEqual(domTreeShapes[0].clientWidth, 10);
     });
   });
+
+  describe('prop: slideClassName', () => {
+    it('should apply a className prop to every rendered slide component', () => {
+      const Slide = () => <div />
+      const classNameToApply = 'someclassname';
+      const wrapper = mount(
+        <SwipeableViews slideClassName={classNameToApply}>
+          <Slide />
+          <Slide />
+        </SwipeableViews>,
+      );
+
+      assert.strictEqual(wrapper.find(Slide)
+        .everyWhere(slide => (slide.parent().prop('className') === classNameToApply)), true, 'should apply the className prop');
+    });
+  });
 });


### PR DESCRIPTION
I found the need to use a class name on the slide component since I use responsive media queries in CSS for the slides.
Instead of using a selector such as .sliderRoot>div>div - I rather just apply a className to the slides.

I hope the added test is enough to make this a simple  PR to merge.