### PR TITLE
-webkit prefix should be used for transform property in -webkit-transition 

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -709,11 +709,14 @@ class SwipeableViews extends Component {
     const slideStyle = Object.assign({}, styles.slide, slideStyleProp);
 
     let transition;
+    let WebkitTransition;
 
     if (isDragging || !animateTransitions || displaySameSlide) {
       transition = 'all 0s ease 0s';
+      WebkitTransition = 'all 0s ease 0s';
     } else {
       transition = createTransition('transform', springConfig);
+      WebkitTransition = createTransition('-webkit-transform', springConfig);
 
       if (heightLatest !== 0) {
         transition += `, ${createTransition('height', springConfig)}`;
@@ -727,7 +730,7 @@ class SwipeableViews extends Component {
       height: null,
       WebkitFlexDirection: axisProperties.flexDirection[axis],
       flexDirection: axisProperties.flexDirection[axis],
-      WebkitTransition: transition,
+      WebkitTransition,
       transition,
     };
 

--- a/packages/react-swipeable-views/src/SwipeableViews.spec.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.spec.js
@@ -154,7 +154,7 @@ describe('SwipeableViews', () => {
       assert.deepEqual(wrapper.childAt(0).props().style, {
         WebkitFlexDirection: 'row',
         WebkitTransform: 'translate(0%, 0)',
-        WebkitTransition: 'transform 0.35s cubic-bezier(0.15, 0.3, 0.25, 1) 0s',
+        WebkitTransition: '-webkit-transform 0.35s cubic-bezier(0.15, 0.3, 0.25, 1) 0s',
         display: 'flex',
         flexDirection: 'row',
         height: null,


### PR DESCRIPTION
Currently the 'transform' uses a prefix for the actual transform value but not for the transition property and I needed this change in order for animated transitions to work in Safari in iOS 8.3. 

One other thing to note is that it wasn't working with multiple transition properties, such as:
```css
-webkit-transition: transform 1s, -webkit-transform 1s;
```
This is why I've just got '-webkit-transform' under '-webkit-transition' and 'transform' under 'transition'. 