### PR TITLE
(fix) Handle rootNode ref loss gracefully

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -430,7 +430,7 @@ class SwipeableViews extends Component {
     } = this.props;
 
     // Latency and rapid rerenders on some devices can leave a period where rootNode briefly equals null
-    if (this.rootNode === null){
+    if (this.rootNode === null) {
       return;
     }
 
@@ -476,7 +476,7 @@ class SwipeableViews extends Component {
       this.handleTouchStart(event);
       return;
     }
-    
+
     // Latency and rapid rerenders on some devices can leave a period where rootNode briefly equals null
     if (this.rootNode === null) {
       return;

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -429,6 +429,11 @@ class SwipeableViews extends Component {
       onTouchStart,
     } = this.props;
 
+    // Latency and rapid rerenders on some devices can leave a period where rootNode briefly equals null
+    if (this.rootNode === null){
+      return;
+    }
+
     if (onTouchStart) {
       onTouchStart(event);
     }
@@ -469,6 +474,11 @@ class SwipeableViews extends Component {
     // Makes sure we set a starting point.
     if (!this.started) {
       this.handleTouchStart(event);
+      return;
+    }
+    
+    // Latency and rapid rerenders on some devices can leave a period where rootNode briefly equals null
+    if (this.rootNode === null) {
       return;
     }
 


### PR DESCRIPTION
Gracefully handles a rootNode reference equaling null.

I am a big fan of this repo (thanks for the awesome work!) and react-virtualized.

I often use the react-virtualized infinite scroller inside of the swipeable views component.
As a result, I can get to pretty large lists calling rerender fairly often while running inside of this component. 

Combining that with running inside a webview on Apache Cordova on iOS (I know we should be using native, but we're already a bit too far down a road here), and it seems like we can get to a small window where the old ref element has been expired and set to null, but the new ref element hasn't been assigned yet.

If this occurs while any of the touchstart events are fired, the page breaks from an uncaught exception emitted by the swipeable views component here:
https://github.com/oliviertassinari/react-swipeable-views/blob/master/packages/react-swipeable-views/src/SwipeableViews.js#L438
(And similarly for touchMoveEvents, wherever the `[null].whatever()` call is)

In my local testing, detecting this state and basically skipping that turn of the event loop seems to keep the UX consistent while still preventing uncaught exceptions from being fired and anything from getting weird.

Once again, thanks for the awesome repo and please let me know your thoughts or any feedback. Thanks!