### PR TITLE
Fix accessibility caused by aria roles

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -147,7 +147,7 @@ export function getDomTreeShapes(element, rootNode) {
 
   while (element && element !== rootNode) {
     // We reach a Swipeable View, no need to look higher in the dom tree.
-    if (element.getAttribute('role') === 'option') {
+    if (element.hasAttribute('data-swipeable')) {
       break;
     }
 
@@ -775,7 +775,6 @@ class SwipeableViews extends Component {
       <div
         ref={(node) => { this.rootNode = node; }}
         style={Object.assign({}, axisProperties.root[axis], style)}
-        role="listbox"
         {...other}
         {...touchEvents}
         onScroll={this.handleScroll}
@@ -808,7 +807,7 @@ class SwipeableViews extends Component {
                 style={slideStyle}
                 className={slideClassName}
                 aria-hidden={hidden}
-                role="option"
+                data-swipeable='true'
               >
                 {child}
               </div>

--- a/packages/react-swipeable-views/src/SwipeableViews.spec.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.spec.js
@@ -426,7 +426,7 @@ describe('SwipeableViews', () => {
   });
 
   describe('getDomTreeShapes', () => {
-    it('should stop at the role === option', () => {
+    it('should stop at the data-swipeable attribute', () => {
       const rootNode = {};
 
       const optionNode = {


### PR DESCRIPTION
The Swipeable View component creates div elements that have attribute "role" with values "listbox" or "option". The "role" attribute indicates to assistive technologies, such as screen readers, what is the semantic meaning of the element. Values "listbox" and "option" should be used only when building a control that acts a lot like the "select" element. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_listbox_role describes well the behaviour of screen readers with these "role" attribute values. In short, the options will be spoken as if they are single lines (like regular "option" element texts are), typing letters selects matching options etc.

The code used role="option" as a marker for certain element in the DOM tree. As possible fix, I replaced the "role" attribute with "data-swipeable" attribute. I wasn't able to test this fix, and there might be better ways to fix the problem. Using the "role" attribute for any purpose it's not truly meant for is however bound to create big problems for screen reader users.

