### PR TITLE
[docs] Add an example for handling RTL

### DIFF
--- a/docs/src/Main.js
+++ b/docs/src/Main.js
@@ -17,6 +17,7 @@ import DemoKeyboard from './demo/DemoKeyboard';
 import DemoVirtualize from './demo/DemoVirtualize';
 import DemoHocs from './demo/DemoHocs';
 import DemoWidth from './demo/DemoWidth';
+import DemoRtl from './demo/DemoRtl';
 import Footer from './Footer';
 
 injectTapEventPlugin();
@@ -103,6 +104,12 @@ const Main = () => (
         description="Custom width of slides."
       >
         <DemoWidth />
+      </Demo>
+      <Demo
+        name="Demo 13"
+        description="Right-to-left direction"
+      >
+        <DemoRtl />
       </Demo>
       <Footer
         maintainerName="oliviertassinari"

--- a/docs/src/demo/DemoRtl.js
+++ b/docs/src/demo/DemoRtl.js
@@ -1,0 +1,44 @@
+// @flow weak
+
+import React from 'react';
+import SwipeableViews from 'react-swipeable-views';
+
+const styles = {
+  root: {
+    // Simulates a global right-to-left direction.
+    direction: 'rtl',
+  },
+  slide: {
+    direction: 'rtl',
+    padding: 15,
+    minHeight: 100,
+    color: '#fff',
+  },
+  slide1: {
+    backgroundColor: '#FEA900',
+  },
+  slide2: {
+    backgroundColor: '#B3DC4A',
+  },
+  slide3: {
+    backgroundColor: '#6AC0FF',
+  },
+};
+
+const DemoRtl = () => (
+  <div style={styles.root}>
+    <SwipeableViews axis="x-reverse">
+      <div style={Object.assign({}, styles.slide, styles.slide1)}>
+        slide n°1
+      </div>
+      <div style={Object.assign({}, styles.slide, styles.slide2)}>
+        slide n°2
+      </div>
+      <div style={Object.assign({}, styles.slide, styles.slide3)}>
+        slide n°3
+      </div>
+    </SwipeableViews>
+  </div>
+);
+
+export default DemoRtl;

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -39,6 +39,7 @@ function injectStyle() {
 
 const styles = {
   container: {
+    direction: 'ltr',
     display: 'flex',
     // Cause an issue on Firefox. We can't enable it for now.
     // willChange: 'transform',

--- a/packages/react-swipeable-views/src/SwipeableViews.spec.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.spec.js
@@ -158,14 +158,10 @@ describe('SwipeableViews', () => {
         </SwipeableViews>,
       );
 
-      assert.deepEqual(wrapper.childAt(0).props().style, {
+      assert.include(wrapper.childAt(0).props().style, {
         WebkitFlexDirection: 'row',
         WebkitTransform: 'translate(0%, 0)',
         WebkitTransition: '-webkit-transform 0.35s cubic-bezier(0.15, 0.3, 0.25, 1) 0s',
-        display: 'flex',
-        flexDirection: 'row',
-        height: null,
-        transform: 'translate(0%, 0)',
         transition: 'transform 0.35s cubic-bezier(0.15, 0.3, 0.25, 1) 0s',
       });
     });


### PR DESCRIPTION
This is quite a hacky workaround. A proper fix would read the direction style computed with `getComputedStyle` and `getPropertyValue` and use the right logic. For now, it's doing the job.
Plus, I don't want to complexify the codebase for a use case I don't have.

Closes #243