### PR TITLE
fix(browser): Bail out from handleTouchMove if 'disabled' property is enabled.

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -481,6 +481,11 @@ class SwipeableViews extends Component {
   };
 
   handleTouchMove = (event) => {
+    // Handling touch events is disabled.
+    if (this.props.disabled) {
+      return;
+    }
+
     // The touch start event can be cancel.
     // Makes sure we set a starting point.
     if (!this.started) {


### PR DESCRIPTION
Before #239 `onTouchMove` was not listened when `disabled` property was enabled. This PR restores the behaviour by returning early from `handleTouchMove`. It fixes situations where swiping causes slides to partially slide in and get stuck when swiping should be disabled.