### PR TITLE
Corrected virtualize HOC props in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ This HOC extends the properties of `<SwipeableViews />` and adds the following o
 
 | Name | Type | Default | Platform | Description |
 |:-----|:-----|:--------|:---------|:------------|
-| overscanSlideCount | integer | `2` | all | Number of slide to render before/after the visible slide. |
+| overscanSlideAfter | integer | `2` | all | Number of slide to render after the visible slide. |
+| overscanSlideBefore | integer | `3` | all | Number of slide to render before the visible slide. Separate from `overscanSlideAfter` as it's more difficult to keep the window up to date.|
 | slideCount | integer | | all | When set, it's adding a limit to the number of slide: [0, slideCount]. |
 | slideRenderer | func | | all | Responsible for rendering a slide given an index. ({ index: integer }): node |
 


### PR DESCRIPTION
Replaced overscanSlideCount with overscanSlideAfter and overscanSlideBefore props.