### PR TITLE
animateHeight={true} workaround

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -399,7 +399,7 @@ class SwipeableViews extends Component {
     return {
       refreshSwipeableContainerHeight: () => {
         this.setState({
-          heightLatest: 0,
+          heightLatest: this.state.heightLatest + 1,
         });
       },
     };

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -389,7 +389,21 @@ class SwipeableViews extends Component {
     resistance: false,
   };
 
+  static childContextTypes = {
+    refreshSwipeableContainerHeight: PropTypes.func,
+  };
+
   state = {};
+
+  getChildContext() {
+    return {
+      refreshSwipeableContainerHeight: () => {
+        this.setState({
+          heightLatest: 0,
+        });
+      },
+    };
+  }
 
   componentWillMount() {
     if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
Quick and dirty hack to workaround `animateHeight={true}` bug during child view resizing

In client code, use:

```
static contextTypes = {
	refreshSwipeableContainerHeight: PropTypes.func.isRequired
};

foo() {
	this.context.refreshSwipeableContainerHeight(); // call it whenever child view resizes
}
```