### PR TITLE
Ignore TransitionEnd events from children

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -428,7 +428,11 @@ class SwipeableViews extends Component {
 
   componentDidMount() {
     // Subscribe to transition end events.
-    this.transitionListener = addEventListenerEnhanced(this.containerNode, transitionInfo.end, () => {
+    this.transitionListener = addEventListenerEnhanced(this.containerNode, transitionInfo.end, (event) => {
+      if (event.target !== this.containerNode) {
+        return;
+      }
+
       this.handleTransitionEnd();
     });
 


### PR DESCRIPTION
Hi,
I have some loading images in slides.. with fade in animation..  and I was getting some random jumps during the slide transitions (suddenly jumped to the end of the transition) and I isolated that its because  TransitionEnd event which bubbles up to the Container and triggers `handleTransitionEnd()` sooner.

Checking if the event is coming from container should be reliable solution to this.

