### PR TITLE
Passes indexCurrent as a parameter for onTransitionEnd callback

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -773,7 +773,7 @@ class SwipeableViews extends Component {
     // The rest callback is triggered when swiping. It's just noise.
     // We filter it out.
     if (!this.state.isDragging) {
-      this.props.onTransitionEnd();
+      this.props.onTransitionEnd(this.state.indexCurrent);
     }
   }
 


### PR DESCRIPTION
Hi there,

Currently I can't get `indexCurrent` in  the `onTransitionEnd` callback. In my case, when I swipe slides via `index` prop, no `onChangeIndex` callback is called and there is no way to access this value. Passing it as a parameter will allow me to do any logic I would do in `onChangeIndex` but after the animation has ended.

I don't know if this is the more suitable solution, but it's a fast one and would help a lot :)

Regards!