### PR TITLE
Support React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/oliviertassinari/react-swipeable-views.git"
   },
   "dependencies": {
-    "react": "16.0.0-alpha.12",
+    "react": "^16.0.0",
     "react-native": "^0.47.2"
   },
   "devDependencies": {


### PR DESCRIPTION
@oliviertassinari 
This is to support the official React 16

not sure should we add `react` in `peerDependencies` or `dependencies` though.

