### PR TITLE
[virtualize] Fix onTransitionEnd call

### DIFF
--- a/packages/react-swipeable-views-utils/src/virtualize.js
+++ b/packages/react-swipeable-views-utils/src/virtualize.js
@@ -179,6 +179,7 @@ export default function virtualize(MyComponent) {
         children,
         index: indexProp,
         onChangeIndex,
+        onTransitionEnd,
         overscanSlideAfter,
         overscanSlideBefore,
         slideCount,


### PR DESCRIPTION
Currently, we pass the onTransitionEnd prop directly to MyComponent which means that whatever function we pass into the onTransitionEnd prop gets called directly by the Swipeable component. The bug here is that the virtualize() handleTransitionEnd function never gets called, so we do not call setWindow() and we keep adding swipeable views without unmounting any. Correct behavior is to either move the {...other} assignment to be before assigning the onTransitionEnd prop under My Component, or removing the onTransitionEnd prop from {...other} through destructive assignment, which makes more sense.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
