### PR TITLE
Improve ref performance

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -369,12 +369,6 @@ class SwipeableViews extends Component {
   handleSwipeStart = event => {
     const { axis } = this.props;
 
-    // Latency and rapid rerenders on some devices can leave
-    // a period where rootNode briefly equals null.
-    if (this.rootNode === null) {
-      return;
-    }
-
     const touch = applyRotationMatrix(event.touches[0], axis);
 
     this.viewLength = this.rootNode.getBoundingClientRect()[axisProperties.length[axis]];
@@ -418,12 +412,6 @@ class SwipeableViews extends Component {
     // Makes sure we set a starting point.
     if (!this.started) {
       this.handleTouchStart(event);
-      return;
-    }
-
-    // Latency and rapid rerenders on some devices
-    // can leave a period where rootNode briefly equals null.
-    if (this.rootNode === null) {
       return;
     }
 

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -337,6 +337,19 @@ class SwipeableViews extends Component {
     }
   }
 
+  setRootNode = node => {
+    this.rootNode = node;
+  };
+
+  setContainerNode = node => {
+    this.containerNode = node;
+  };
+
+  setActiveSlide = node => {
+    this.activeSlide = node;
+    this.updateHeight();
+  };
+
   rootNode = null;
   containerNode = null;
   ignoreNextScrollEvents = false;
@@ -791,9 +804,7 @@ So animateHeight is most likely having no effect at all.`,
 
     return (
       <div
-        ref={node => {
-          this.rootNode = node;
-        }}
+        ref={this.setRootNode}
         style={Object.assign({}, axisProperties.root[axis], style)}
         {...other}
         {...touchEvents}
@@ -801,9 +812,7 @@ So animateHeight is most likely having no effect at all.`,
         onScroll={this.handleScroll}
       >
         <div
-          ref={node => {
-            this.containerNode = node;
-          }}
+          ref={this.setContainerNode}
           style={Object.assign({}, containerStyle, styles.container, containerStyleProp)}
           className="react-swipeable-view-container"
         >
@@ -825,10 +834,7 @@ We are expecting a valid React Element`,
               hidden = false;
 
               if (animateHeight) {
-                ref = node => {
-                  this.activeSlide = node;
-                  this.updateHeight();
-                };
+                ref = this.setActiveSlide;
                 slideStyle.overflowY = 'hidden';
               }
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Great library! I'm the maintainer of [react-swipeable](https://github.com/dogfessional/react-swipeable) and just wanted to see how this library handled some things and noticed these could get "cleaned up" 😸 

- update ref assignment inline functions to use class methods
  - avoids new function creation on each render
  - avoids `null` assignments
  - https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs

~Could probably clean up these lines too after/with this PR:
https://github.com/oliviertassinari/react-swipeable-views/blob/master/packages/react-swipeable-views/src/SwipeableViews.js#L359-L363~
- cleaned up `null` checks 😸 

Let me know, cheers!