### PR TITLE
Fix padding while swiping

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -371,7 +371,11 @@ class SwipeableViews extends React.Component {
 
     const touch = applyRotationMatrix(event.touches[0], axis);
 
-    this.viewLength = this.rootNode.getBoundingClientRect()[axisProperties.length[axis]];
+    const rootStyle = window.getComputedStyle(this.rootNode);
+    this.viewLength =
+      this.rootNode.getBoundingClientRect()[axisProperties.length[axis]] -
+      parseInt(rootStyle.paddingLeft, 10) -
+      parseInt(rootStyle.paddingRight, 10);
     this.startX = touch.pageX;
     this.lastX = touch.pageX;
     this.vx = 0;
@@ -389,7 +393,6 @@ class SwipeableViews extends React.Component {
         .split('(')[1]
         .split(')')[0]
         .split(',');
-      const rootStyle = window.getComputedStyle(this.rootNode);
 
       const tranformNormalized = applyRotationMatrix(
         {
@@ -399,11 +402,7 @@ class SwipeableViews extends React.Component {
         axis,
       );
 
-      this.startIndex =
-        -tranformNormalized.pageX /
-          (this.viewLength -
-            parseInt(rootStyle.paddingLeft, 10) -
-            parseInt(rootStyle.paddingRight, 10)) || 0;
+      this.startIndex = -tranformNormalized.pageX / this.viewLength || 0;
     }
   };
 


### PR DESCRIPTION
Issue:
- If you add padding to the container (i.e. to
 preview prev & next items), then the swype gesture
 will show a gap between finger position and
 the slides moving.
- While handleSwipeStart takes into account the viewport paddings,
 handleSwipeMove did not.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This solves #444