### PR TITLE
Initialize this.state before calling setIndexCurrent

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -231,7 +231,6 @@ class SwipeableViews extends React.Component {
       checkIndexBounds(this.props);
     }
 
-    this.setIndexCurrent(this.props.index);
     this.state = {
       indexLatest: this.props.index,
       // Set to true as soon as the component is swiping.
@@ -243,6 +242,8 @@ class SwipeableViews extends React.Component {
       // Let the render method that we are going to display the same slide than previously.
       displaySameSlide: true,
     };
+
+    this.setIndexCurrent(this.props.index);
   }
 
   getChildContext() {

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -242,7 +242,6 @@ class SwipeableViews extends React.Component {
       // Let the render method that we are going to display the same slide than previously.
       displaySameSlide: true,
     };
-
     this.setIndexCurrent(this.props.index);
   }
 

--- a/packages/react-swipeable-views/src/SwipeableViews.spec.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.spec.js
@@ -11,6 +11,8 @@ function simulateSwipeMove(wrapper, event) {
   });
 }
 
+function noop() {}
+
 describe('SwipeableViews', () => {
   describe('prop: children', () => {
     it('should render the children', () => {
@@ -199,7 +201,7 @@ describe('SwipeableViews', () => {
 
     it('should not use a spring if animateTransitions is false', () => {
       const wrapper = shallow(
-        <SwipeableViews animateTransitions={false}>
+        <SwipeableViews animateTransitions={false} index={1} onTransitionEnd={noop}>
           <div>{'slide n°1'}</div>
         </SwipeableViews>,
         { disableLifecycleMethods: true },


### PR DESCRIPTION
```console
$ yarn test:unit
yarn run v1.7.0
$ cross-env NODE_ENV=test mocha


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․!․․․․․․․․․․․․․․․․

  69 passing (2s)
  1 failing

  1) SwipeableViews
       prop: animateTransitions
         should not use a spring if animateTransitions is false:
     TypeError: Cannot read property 'displaySameSlide' of undefined
      at SwipeableViews.handleTransitionEnd (packages/react-swipeable-views/src/SwipeableViews.js:647:20)
      at SwipeableViews.setIndexCurrent (packages/react-swipeable-views/src/SwipeableViews.js:327:12)
      at new SwipeableViews (packages/react-swipeable-views/src/SwipeableViews.js:234:10)
      at ReactShallowRenderer.render (node_modules/react-test-renderer/cjs/react-test-renderer-shallow.development.js:131:26)
      at /Users/ykzts/works/ykzts/react-swipeable-views/node_modules/enzyme-adapter-react-16/build/ReactSixteenAdapter.js:287:35
      at withSetStateAllowed (node_modules/enzyme-adapter-utils/build/Utils.js:94:16)
      at Object.render (node_modules/enzyme-adapter-react-16/build/ReactSixteenAdapter.js:286:68)
      at new ShallowWrapper (node_modules/enzyme/build/ShallowWrapper.js:119:22)
      at shallow (node_modules/enzyme/build/shallow.js:19:10)
      at Context.<anonymous> (packages/react-swipeable-views/src/SwipeableViews.spec.js:201:23)



error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

😢