### PR TITLE
Fix lazy loading

### DIFF
--- a/packages/react-swipeable-views-utils/src/virtualize.js
+++ b/packages/react-swipeable-views-utils/src/virtualize.js
@@ -6,9 +6,9 @@ export default function virtualize(MyComponent) {
   class Virtualize extends PureComponent {
     timer = null;
 
-    constructor(props, context) {
-      super(props, context);
-      this.state.index = this.props.index || 0;
+    constructor(props) {
+      super(props);
+      this.state.index = props.index || 0;
     }
 
     /**

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -254,6 +254,8 @@ class SwipeableViews extends React.Component {
 
   indexCurrent = null;
 
+  firstRenderTimeoutHandle = null;
+
   constructor(props, context) {
     super(props, context);
 
@@ -315,10 +317,16 @@ class SwipeableViews extends React.Component {
       },
     );
 
-    // eslint-disable-next-line react/no-did-mount-set-state
-    this.setState({
-      isFirstRender: false,
-    });
+    const markNoLongerFirstRender = () => {
+      this.setState({
+        isFirstRender: false,
+      });
+    };
+    if (this.props.disableLazyLoading) {
+      markNoLongerFirstRender();
+    } else {
+      this.firstRenderTimeoutHandle = setTimeout(markNoLongerFirstRender, 0);
+    }
 
     injectStyle();
 
@@ -350,6 +358,7 @@ class SwipeableViews extends React.Component {
   componentWillUnmount() {
     this.transitionListener.remove();
     this.touchMoveListener.remove();
+    clearTimeout(this.firstRenderTimeoutHandle);
   }
 
   setIndexCurrent(indexCurrent) {

--- a/packages/react-swipeable-views/src/SwipeableViews.test.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { assert } from 'chai';
-import { spy, stub } from 'sinon';
+import { spy, stub, useFakeTimers } from 'sinon';
 import SwipeableViews, { findNativeHandler, getDomTreeShapes } from './SwipeableViews';
 
 function simulateSwipeMove(wrapper, event) {
@@ -15,9 +15,9 @@ function noop() {}
 
 describe('SwipeableViews', () => {
   describe('prop: children', () => {
-    it('should render the children', () => {
+    it('should render the children when lazy loading turned off', () => {
       const wrapper = mount(
-        <SwipeableViews>
+        <SwipeableViews disableLazyLoading>
           <div>{'slide n°1'}</div>
           <div>{'slide n°2'}</div>
           <div>{'slide n°3'}</div>
@@ -174,7 +174,7 @@ describe('SwipeableViews', () => {
   describe('prop: animateTransitions', () => {
     it('should use a spring if animateTransitions is true', () => {
       const wrapper = mount(
-        <SwipeableViews>
+        <SwipeableViews disableLazyLoading>
           <div>{'slide n°1'}</div>
         </SwipeableViews>,
         { disableLifecycleMethods: true },
@@ -607,6 +607,7 @@ describe('SwipeableViews', () => {
       });
 
       it('should render all the children during the second render', () => {
+        const clock = useFakeTimers();
         const wrapper = mount(
           <SwipeableViews index={1}>
             <div>{'slide n°1'}</div>
@@ -615,8 +616,10 @@ describe('SwipeableViews', () => {
             <div>{'slide n°4'}</div>
             <div>{'slide n°5'}</div>
           </SwipeableViews>,
-          { disableLifecycleMethods: true },
         );
+        clock.tick(1);
+        wrapper.update();
+        clock.restore();
 
         assert.strictEqual(wrapper.text(), 'slide n°1slide n°2slide n°3slide n°4slide n°5');
         assert.shallowDeepEqual(

--- a/packages/react-swipeable-views/src/SwipeableViews.test.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.test.js
@@ -15,7 +15,7 @@ function noop() {}
 
 describe('SwipeableViews', () => {
   describe('prop: children', () => {
-    it('should render the children when lazy loading turned off', () => {
+    it('should render the children', () => {
       const wrapper = mount(
         <SwipeableViews disableLazyLoading>
           <div>{'slide n°1'}</div>
@@ -26,11 +26,7 @@ describe('SwipeableViews', () => {
         </SwipeableViews>,
       );
 
-      assert.strictEqual(
-        wrapper.text(),
-        'slide n°1slide n°2slide n°3slide n°4slide n°5',
-        'Should render each slide.',
-      );
+      assert.strictEqual(wrapper.text(), 'slide n°1slide n°2slide n°3slide n°4slide n°5');
     });
   });
 
@@ -139,7 +135,7 @@ describe('SwipeableViews', () => {
       wrapper.simulate('touchStart', {
         touches: [{}],
       });
-      assert.strictEqual(handleTouchStart.callCount, 1, 'Should be called');
+      assert.strictEqual(handleTouchStart.callCount, 1);
     });
 
     it('should trigger when we disable the swipe', () => {
@@ -153,7 +149,7 @@ describe('SwipeableViews', () => {
       wrapper.simulate('touchStart', {
         touches: [{}],
       });
-      assert.strictEqual(handleTouchStart.callCount, 1, 'Should be called');
+      assert.strictEqual(handleTouchStart.callCount, 1);
     });
   });
 
@@ -167,7 +163,7 @@ describe('SwipeableViews', () => {
       );
 
       wrapper.simulate('touchEnd');
-      assert.strictEqual(handleTouchEnd.callCount, 1, 'Should be called');
+      assert.strictEqual(handleTouchEnd.callCount, 1);
     });
   });
 
@@ -177,7 +173,6 @@ describe('SwipeableViews', () => {
         <SwipeableViews disableLazyLoading>
           <div>{'slide n°1'}</div>
         </SwipeableViews>,
-        { disableLifecycleMethods: true },
       );
 
       wrapper.setProps({
@@ -587,6 +582,16 @@ describe('SwipeableViews', () => {
 
   describe('prop: disableLazyLoading', () => {
     describe('false', () => {
+      let clock;
+
+      beforeEach(() => {
+        clock = useFakeTimers();
+      });
+
+      afterEach(() => {
+        clock.restore();
+      });
+
       it('should render the right child', () => {
         const wrapper = shallow(
           <SwipeableViews index={1}>
@@ -607,7 +612,6 @@ describe('SwipeableViews', () => {
       });
 
       it('should render all the children during the second render', () => {
-        const clock = useFakeTimers();
         const wrapper = mount(
           <SwipeableViews index={1}>
             <div>{'slide n°1'}</div>
@@ -617,10 +621,10 @@ describe('SwipeableViews', () => {
             <div>{'slide n°5'}</div>
           </SwipeableViews>,
         );
+
+        assert.strictEqual(wrapper.text(), 'slide n°2');
         clock.tick(1);
         wrapper.update();
-        clock.restore();
-
         assert.strictEqual(wrapper.text(), 'slide n°1slide n°2slide n°3slide n°4slide n°5');
         assert.shallowDeepEqual(
           wrapper


### PR DESCRIPTION
I've been using this fix in production for a few weeks. It worked well and I didn't need to do any other fix after the change. 

Closes #453 

To be honest, I am not familiar with enzyme, especially how lifecycle and first render/second render works in it.
I am confused by how the test 'prop: disableLazyLoading' was written. Does it mean mounting the same component twice in consecutive tests will count as first render and then second render?

I'd really like some suggestions on that, I tried some fixes just to pass the test.