### PR TITLE
Pull out legacy browser support CSS

### DIFF
--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -101,7 +101,7 @@ function AppDrawer(props, context) {
         <div className={classes.toolbar}>
           <Link className={classes.title} href="/" onClick={onClose}>
             <Typography variant="title" color="inherit">
-              Material-UI
+              react-swipeable-views
             </Typography>
           </Link>
           {process.env.LIB_VERSION ? (

--- a/docs/src/pages/getting-started/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms.md
@@ -1,6 +1,6 @@
 ## Supported platforms
 
-<p class="description">Learn about the platforms, from modern to old, that are supported by Material-UI.</p>
+<p class="description">Learn about the platforms, from modern to old, that are supported by react-swipeable-views.</p>
 
 The API is as consistent as possible between the three platforms so
 the same component can be used independently on where it's running.
@@ -10,6 +10,10 @@ the same component can be used independently on where it's running.
 | IE    | Edge | Windows Phone | Firefox | Chrome | Safari |
 |:------|:-----|:--------------|:--------|:-------|:-------|
 | >= 10 | ✓    | x             | >= 28   | >= 29  | >= 8   |
+
+#### Legacy browser support
+
+react-swipeable-views supports modern browsers out-of-the-box, but requires additional CSS to support legacy browsers. To support IE 10 and older versions of Mobile Safari, include `react-swipeable-views/dist/legacy-browser-support.css`.
 
 ![browser](/static/platformBrowser.gif)
 

--- a/packages/react-swipeable-views/.npmignore
+++ b/packages/react-swipeable-views/.npmignore
@@ -1,4 +1,5 @@
 /*
 !/src/*.js
 !/lib/*.js
+!/dist/*
 *.test.js

--- a/packages/react-swipeable-views/dist/legacy-browser-support.css
+++ b/packages/react-swipeable-views/dist/legacy-browser-support.css
@@ -1,0 +1,8 @@
+.react-swipeable-view-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
+}
+
+.react-swipeable-view-container > div {
+  -ms-flex-negative: 0;
+}

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -20,31 +20,6 @@ function addEventListenerEnhanced(node, event, handler, options) {
   };
 }
 
-let styleInjected = false;
-
-// Support old version of iOS and IE 10.
-// To be deleted in 2019.
-function injectStyle() {
-  // Inject once for all the instances
-  if (!styleInjected) {
-    const style = document.createElement('style');
-    style.innerHTML = `
-      .react-swipeable-view-container {
-        display: -webkit-box;
-        display: -ms-flexbox;
-      }
-      .react-swipeable-view-container > div {
-        -ms-flex-negative: 0;
-      }
-    `;
-
-    if (document.body) {
-      document.body.appendChild(style);
-    }
-    styleInjected = true;
-  }
-}
-
 const styles = {
   container: {
     direction: 'ltr',
@@ -324,8 +299,6 @@ class SwipeableViews extends React.Component {
         });
       }, 0);
     }
-
-    injectStyle();
 
     // Send all functions in an object if action param is set.
     if (this.props.action) {


### PR DESCRIPTION
Fixes https://github.com/oliviertassinari/react-swipeable-views/issues/465

I think there's not much harm to keeping around the CSS, but keeping it in a separate distributed file, such that people who need to support older browsers can just include the CSS themselves.

Strikes a nice mix of avoiding cruft for sites that only support modern browsers, while maintaining a CSP-friendly way of adding in support for legacy browsers.

Thoughts?