### PR TITLE
change getDisplaySameSlide.js to handle children arrays

### DIFF
--- a/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
+++ b/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const getDisplaySameSlide = (props, nextProps) => {
   let displaySameSlide = false;
-  const getChildrenKey = (child) => typeof child !== "number" && typeof child !== "string" ? child.key : 'empty';
+  const getChildrenKey = (child) => child.key || 'empty';
 
   if (props.children.length && nextProps.children.length) {
     const oldKeys = React.Children.map(props.children, getChildrenKey);

--- a/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
+++ b/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const getDisplaySameSlide = (props, nextProps) => {
   let displaySameSlide = false;
-  const getChildrenKey = (child) => child.key || 'empty';
+  const getChildrenKey = child => child.key || 'empty';
 
   if (props.children.length && nextProps.children.length) {
     const oldKeys = React.Children.map(props.children, getChildrenKey);

--- a/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
+++ b/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const getDisplaySameSlide = (props, nextProps) => {
   let displaySameSlide = false;
-  const getChildrenKey = child => child.key || 'empty';
+  const getChildrenKey = child => child ? child.key : 'empty';
 
   if (props.children.length && nextProps.children.length) {
     const oldKeys = React.Children.map(props.children, getChildrenKey);

--- a/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
+++ b/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const getDisplaySameSlide = (props, nextProps) => {
   let displaySameSlide = false;
-  const getChildrenKey = child => child ? child.key : 'empty';
+  const getChildrenKey = child => (child ? child.key : 'empty');
 
   if (props.children.length && nextProps.children.length) {
     const oldKeys = React.Children.map(props.children, getChildrenKey);

--- a/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
+++ b/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
@@ -2,15 +2,15 @@ import React from 'react';
 
 const getDisplaySameSlide = (props, nextProps) => {
   let displaySameSlide = false;
-  const getChildrenKey = child => (child ? child.key : 'empty');
+  const getChildrenKey = child => (child ? child.key : null);
 
   if (props.children.length && nextProps.children.length) {
     const oldKeys = React.Children.map(props.children, getChildrenKey);
-    const oldKey = oldKeys[props.index] || 'empty';
+    const oldKey = oldKeys[props.index] || null;
 
-    if (oldKey !== null) {
+    if (oldKey !== null && oldKey !== undefined) {
       const newKeys = React.Children.map(nextProps.children, getChildrenKey);
-      const newKey = newKeys[nextProps.index] || 'empty';
+      const newKey = newKeys[nextProps.index] || null;
 
       if (oldKey === newKey) {
         displaySameSlide = true;

--- a/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
+++ b/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
@@ -1,13 +1,16 @@
+import React from 'react';
+
 const getDisplaySameSlide = (props, nextProps) => {
   let displaySameSlide = false;
+  const getChildrenKey = (child) => typeof child !== "number" && typeof child !== "string" ? child.key : 'empty';
 
   if (props.children.length && nextProps.children.length) {
-    const oldChildren = props.children[props.index];
-    const oldKey = oldChildren ? oldChildren.key : 'empty';
+    const oldKeys = React.Children.map(props.children, getChildrenKey);
+    const oldKey = oldKeys[props.index] || 'empty';
 
     if (oldKey !== null) {
-      const newChildren = nextProps.children[nextProps.index];
-      const newKey = newChildren ? newChildren.key : 'empty';
+      const newKeys = React.Children.map(nextProps.children, getChildrenKey);
+      const newKey = newKeys[nextProps.index] || 'empty';
 
       if (oldKey === newKey) {
         displaySameSlide = true;


### PR DESCRIPTION
Current code of getDisplaySameSlide.js was not handling correctly the situation of having children inside an array (common case for dynamic amount of children).
Updated the code so that we use React.Children that traverses nested children arrays

Fixes https://github.com/oliviertassinari/react-swipeable-views/issues/476
