### PR TITLE
Fix onChangeIndex is not passed when autoplay is disabled

### DIFF
--- a/packages/react-swipeable-views-utils/src/autoPlay.js
+++ b/packages/react-swipeable-views-utils/src/autoPlay.js
@@ -128,7 +128,7 @@ export default function autoPlay(MyComponent) {
       const { index } = this.state;
 
       if (!autoplay) {
-        return <MyComponent index={index} {...other} />;
+        return <MyComponent index={index} onChangeIndex={onChangeIndex} {...other} />;
       }
 
       return (

--- a/packages/react-swipeable-views-utils/src/autoPlay.test.js
+++ b/packages/react-swipeable-views-utils/src/autoPlay.test.js
@@ -197,6 +197,26 @@ describe('autoPlay', () => {
           done();
         }, 300);
       });
+
+      it('should pass onChangeIndex also when autoplay is disabled', done => {
+        const handleChangeIndex = spy();
+
+        wrapper = shallow(
+          <AutoPlaySwipeableViews index={0} autoplay={false} onChangeIndex={handleChangeIndex}>
+            <div>{'slide n°1'}</div>
+            <div>{'slide n°2'}</div>
+            <div>{'slide n°3'}</div>
+          </AutoPlaySwipeableViews>,
+        );
+
+        wrapper.find(Empty).simulate('changeIndex', 1, 0);
+        assert.strictEqual(
+          handleChangeIndex.callCount,
+          1,
+          'Should be called the right number of time.',
+        );
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
The `onChangeIndex` prop is not passed to target component when `autoplay` prop is `false`.

For example, the `handleIndexChange` method never called even the user swipe the slide.
```
import SwipeableViews from 'react-swipeable-views'
import { virtualize, autoPlay } from 'react-swipeable-views-utils'

const VirtualizedSwipeableViews = autoPlay(virtualize(SwipeableViews))

class CarouselComponent extends React.Component {
  state = { index: 0 }

  handleIndexChange = (index, indexLatest, meta) => {
    console.log(index, indexLatest, meta)
    this.setState({ index })
  }

  slideRenderer = ({ index }) => {
    return this.props.children[index]
  }

  render() {
    <VirtualizedSwipeableViews
      {...swipeOptions}
      slideCount={this.props.children.length}
      slideRenderer={this.slideRenderer}
      index={index}
      onChangeIndex={this.handleIndexChange}
    />
  }
}
```

This PR fix this.