### PR TITLE
add prop 'animateWithLeft' to animate x axis with left css property

### DIFF
--- a/docs/src/pages/api/api.md
+++ b/docs/src/pages/api/api.md
@@ -9,6 +9,7 @@
 | action | function(hooks) |  | browser | This is callback property. It's called by the component on mount. This is useful when you want to trigger an action programmatically. It currently only supports updateHeight() action. |
 | animateHeight | bool | `false` | browser | If `true`, the height of the container will be animated to match the current slide height. Animating another style property has a negative impact regarding performance. |
 | animateTransitions | bool | `true` | all | If `false`, changes to the index prop will not cause an animated transition. |
+| animateWithLeft | bool | `true` | browser | Animate slides on `x` axis with left property (and not with transform) |
 | axis | enum [`'x'`, `'x-reverse'`, `'y'`, `'y-reverse'`] | `'x'` | browser | The axis on which the slides will slide. |
 | children | node | | all | Use this property to provide your slides. |
 | containerStyle | object | `{}` | all | This is the inlined style that will be applied to each slide container. |

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -345,8 +345,8 @@ class SwipeableViews extends React.Component {
         this.containerNode.style.position = 'relative';
         this.containerNode.style.left = transform;
       } else {
-        this.containerNode.style.WebkitTransform = `translate: ${transform}`;
-        this.containerNode.style.transform = `translate: ${transform}`;
+        this.containerNode.style.WebkitTransform = `translate(${transform}, 0)`;
+        this.containerNode.style.transform = `translate(${transform}, 0)`;
       }
     }
   }
@@ -794,8 +794,8 @@ So animateHeight is most likely having no effect at all.`,
         containerStyle.position = 'relative';
         containerStyle.left = transform;
       } else {
-        containerStyle.WebkitTransform = `translate: ${transform}`;
-        containerStyle.transform = `translate: ${transform}`;
+        containerStyle.WebkitTransform = `translate(${transform}, 0)`;
+        containerStyle.transform = `translate(${transform}, 0)`;
       }
     }
 

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -888,6 +888,13 @@ SwipeableViews.propTypes = {
    */
   animateTransitions: PropTypes.bool,
   /**
+   * Transform makes the element `position: relative`
+   * and `overflow: hidden`, animating slide transitions
+   * with `left` property does not assume the user wants
+   * these two css styles
+   */
+  animateWithLeft: PropTypes.bool,
+  /**
    * The axis on which the slides will slide.
    */
   axis: PropTypes.oneOf(['x', 'x-reverse', 'y', 'y-reverse']),
@@ -1040,6 +1047,7 @@ SwipeableViews.defaultProps = {
     delay: '0s',
   },
   resistance: false,
+  animateWithLeft: false,
 };
 
 SwipeableViews.childContextTypes = {


### PR DESCRIPTION
I have a situation where i cant animate the container with `transform` property. I know it is better than moving with `left` property for performance, but as i mentioned in the code, there are two bad things on this approach: Transform makes the element `position: relative` and (the most important, the why of this PR) it makes the element get `overflow: hidden`.

In my case, inside the container i have an element with `position: fixed`, like a modal that needs to get in front of everything, and transform cuts the behavior it needs.