### PR TITLE
[WIP] getDisplaySameSlide.js support dynamic children

### DIFF
--- a/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
+++ b/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 const getDisplaySameSlide = (props, nextProps) => {
   let displaySameSlide = false;
-  let oldChildren = React.Children.toArray(props.children);
-  let nextChildren = React.Children.toArray(nextProps.children);
+  const oldChildren = React.Children.toArray(props.children);
+  const nextChildren = React.Children.toArray(nextProps.children);
   if (oldChildren.length && nextChildren.length) {
     const oldChild = oldChildren[props.index];
     const oldKey = oldChild ? oldChild.key : 'empty';

--- a/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
+++ b/packages/react-swipeable-views-core/src/getDisplaySameSlide.js
@@ -1,13 +1,16 @@
+import React from 'react';
+
 const getDisplaySameSlide = (props, nextProps) => {
   let displaySameSlide = false;
-
-  if (props.children.length && nextProps.children.length) {
-    const oldChildren = props.children[props.index];
-    const oldKey = oldChildren ? oldChildren.key : 'empty';
+  let oldChildren = React.Children.toArray(props.children);
+  let nextChildren = React.Children.toArray(nextProps.children);
+  if (oldChildren.length && nextChildren.length) {
+    const oldChild = oldChildren[props.index];
+    const oldKey = oldChild ? oldChild.key : 'empty';
 
     if (oldKey !== null) {
-      const newChildren = nextProps.children[nextProps.index];
-      const newKey = newChildren ? newChildren.key : 'empty';
+      const newChild = nextChildren[nextProps.index];
+      const newKey = newChild ? newChild.key : 'empty';
 
       if (oldKey === newKey) {
         displaySameSlide = true;


### PR DESCRIPTION
Use React.Children.toArray so that dynamically generated children (e.g results of `Array.map`) are not considered like a single item.
fix #440 fix #476

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
