### PR TITLE
Pause autoPlay when the window is hidden

### DIFF
--- a/packages/react-swipeable-views-utils/src/autoPlay.js
+++ b/packages/react-swipeable-views-utils/src/autoPlay.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import shallowEqual from 'fbjs/lib/shallowEqual';
+import EventListener from 'react-event-listener';
 import { mod } from 'react-swipeable-views-core';
 
 export default function autoPlay(MyComponent) {
@@ -105,6 +106,14 @@ export default function autoPlay(MyComponent) {
       }
     };
 
+    handleVisibilityChange = e => {
+      if (e.target.hidden) {
+        clearInterval(this.timer);
+      } else {
+        this.startInterval();
+      }
+    };
+
     startInterval() {
       const { autoplay, interval } = this.props;
 
@@ -132,12 +141,14 @@ export default function autoPlay(MyComponent) {
       }
 
       return (
-        <MyComponent
-          index={index}
-          onChangeIndex={this.handleChangeIndex}
-          onSwitching={this.handleSwitching}
-          {...other}
-        />
+        <EventListener target="document" onVisibilityChange={this.handleVisibilityChange}>
+          <MyComponent
+            index={index}
+            onChangeIndex={this.handleChangeIndex}
+            onSwitching={this.handleSwitching}
+            {...other}
+          />
+        </EventListener>
       );
     }
   }

--- a/packages/react-swipeable-views-utils/src/autoPlay.test.js
+++ b/packages/react-swipeable-views-utils/src/autoPlay.test.js
@@ -217,6 +217,72 @@ describe('autoPlay', () => {
         );
         done();
       });
+
+      it('should be paused when the window is hidden', done => {
+        wrapper = shallow(
+          <AutoPlaySwipeableViews interval={100}>
+            <div>{'slide n°1'}</div>
+            <div>{'slide n°2'}</div>
+            <div>{'slide n°3'}</div>
+          </AutoPlaySwipeableViews>,
+        );
+        setTimeout(() => {
+          wrapper.simulate('visibilityChange', {
+            target: {
+              hidden: true,
+            },
+          });
+          setTimeout(() => {
+            assert.strictEqual(wrapper.state().index, 1);
+            done();
+          }, 150);
+        }, 150);
+      });
+
+      it('should be resumed when the window is visible', done => {
+        wrapper = shallow(
+          <AutoPlaySwipeableViews interval={100}>
+            <div>{'slide n°1'}</div>
+            <div>{'slide n°2'}</div>
+            <div>{'slide n°3'}</div>
+          </AutoPlaySwipeableViews>,
+        );
+        setTimeout(() => {
+          wrapper.simulate('visibilityChange', {
+            target: {
+              hidden: true,
+            },
+          });
+          wrapper.simulate('visibilityChange', {
+            target: {
+              hidden: false,
+            },
+          });
+          setTimeout(() => {
+            assert.strictEqual(wrapper.state().index, 2);
+            done();
+          }, 150);
+        }, 150);
+      });
+
+      it('should not be resumed when the window is visible but autoplay is false', done => {
+        wrapper = shallow(
+          <AutoPlaySwipeableViews interval={100} autoplay={false}>
+            <div>{'slide n°1'}</div>
+            <div>{'slide n°2'}</div>
+            <div>{'slide n°3'}</div>
+          </AutoPlaySwipeableViews>,
+        );
+        wrapper.simulate('visibilityChange', {
+          target: {
+            hidden: false,
+          },
+        });
+        setTimeout(() => {
+          assert.strictEqual(wrapper.state().index, 0);
+          done();
+        }, 150);
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes #508 by pausing the autoPlay animation if the document is hidden, using the Page Visibility API.