### PR TITLE
Switch virtualize hoc parent from PureComponent to Component

### DIFF
--- a/packages/react-swipeable-views-utils/src/virtualize.js
+++ b/packages/react-swipeable-views-utils/src/virtualize.js
@@ -1,9 +1,9 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { mod } from 'react-swipeable-views-core';
 
 export default function virtualize(MyComponent) {
-  class Virtualize extends PureComponent {
+  class Virtualize extends React.Component {
     timer = null;
 
     constructor(props) {


### PR DESCRIPTION
When using virtualize HOC, child slides are not re-rendered whenever their props change.

[Demo](https://codesandbox.io/s/material-demo-l54hy)

See [React.PureComponent](https://reactjs.org/docs/react-api.html#reactpurecomponent):
> ... Furthermore, React.PureComponent’s shouldComponentUpdate() skips prop updates for the whole component subtree. Make sure all the children components are also “pure”.

Besides that, [autoPlay](https://github.com/oliviertassinari/react-swipeable-views/blob/v0.13.3/packages/react-swipeable-views-utils/src/autoPlay.js) and [bindKeyboard](https://github.com/oliviertassinari/react-swipeable-views/blob/v0.13.3/packages/react-swipeable-views-utils/src/bindKeyboard.js) do not use PureComponent.