### PR TITLE
Round indexes to whole numbers

### DIFF
--- a/native/packages/react-swipeable-views-native/src/SwipeableViews.scroll.tsx
+++ b/native/packages/react-swipeable-views-native/src/SwipeableViews.scroll.tsx
@@ -171,8 +171,8 @@ class SwipeableViews extends React.Component<Props, State> {
   };
 
   handleMomentumScrollEnd = event => {
-    const indexNew = event.nativeEvent.contentOffset.x / this.state.viewWidth;
-    const indexLatest = this.state.indexLatest;
+    const indexNew = Math.round(event.nativeEvent.contentOffset.x / this.state.viewWidth);
+    const indexLatest = Math.round(this.state.indexLatest);
 
     this.setState(
       {


### PR DESCRIPTION
This prevents a number of swipe transition issues in React Native. 

1) When swiping left quickly on slide index 0, the index often falls below. eg: -0.00257788, and the same when you swipe past the slide list length, eg. 6.05.
2) Swiping between slides sometimes leave a stuck transition, or slightly off alignment. Again, because of floating point indexes.

This came about when setting a separate category list, based on the index, and then updating the component using the index={this.state.category}. Reason is that I can then also select a category from the dropdown, and it goes to the correct slide. i'd assume this could be a pretty common use case. 

Screen captures: 
Issue: https://drive.google.com/open?id=13j_1n9PBFlm5yViA4290AUHT70VWL-Tk
Resolved: https://drive.google.com/open?id=1kmF1YbPDj3eQRL40HIiqVeic5ynud-8s

Keep up the good work on the lib. I've spend literally days trying to get other popular libs to work and this now works like a charm after finally tracking down this issue. 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->