### PR TITLE
Update height when receiving new children

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -325,6 +325,15 @@ class SwipeableViews extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    // If animateHeight is on
+    // and has changed children, readjust height
+    const { animateHeight, children } = this.props;
+    if (animateHeight === true && prevProps.children !== children) {
+      this.updateHeight();
+    }
+  }
+
   componentWillUnmount() {
     this.transitionListener.remove();
     this.touchMoveListener.remove();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
## Dynamic container height issue
This PR is a fix to the container (view) height not updating itself after it receives new children.  

Here is the [original issue](https://github.com/oliviertassinari/react-swipeable-views/issues/535).

## Height animation
Personally I don't want this container height update to be animated so I'll remove that in my fork. But I think you want to keep that animation mandatory there so this PR doesn't touch that.