### PR TITLE
fix(react-swipeable-views-utils): Missing peer dep warning in yarn v2

### DIFF
--- a/packages/react-swipeable-views-utils/package.json
+++ b/packages/react-swipeable-views-utils/package.json
@@ -22,6 +22,9 @@
     "react-event-listener": "^0.6.0",
     "react-swipeable-views-core": "^0.13.1"
   },
+  "peerDependencies": {
+    "react": "^16.3.0"
+  },
   "devDependencies": {
     "pkgfiles": "^2.3.2"
   },


### PR DESCRIPTION
Fixes `➤ YN0002: │ react-swipeable-views-utils@npm:0.13.3 doesn't provide react@^16.3.0 requested by react-event-listener@npm:0.6.6` using `yarn@2.0.0-rc.1`

More context in https://github.com/yarnpkg/berry/issues/3