### PR TITLE
Add possibility to prevent swipe dinamically i.e. short-circuit inside onTouchStart()

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -582,7 +582,10 @@ class SwipeableViews extends React.Component {
 
   handleTouchStart = event => {
     if (this.props.onTouchStart) {
-      this.props.onTouchStart(event);
+      const shouldReturn = this.props.onTouchStart(event);
+      if (shouldReturn) {
+        return;
+      }
     }
     this.handleSwipeStart(event);
   };


### PR DESCRIPTION
Hi,

I'd like to discuss this little change because we have a specific use case that can only be solved reliably by doing this, as far as I can tell. 

The idea here is that if we return something _truthy_ the swipe will be prevented.

The use case is that we have a virtualized list inside the swipe container... so the component cannot detect that the list is scrolling (indeed because there's no _real_ scroll), and it swipes even if we still have scroll in the list... 😅 

The other approach would be to set the `disabled` prop dynamically with `setState()`, but it's junky/buggy because we can swipe up and down even outside the list container. Imagine that inside the swipe container we have 1) an header with a fixed height plus 2) a virtual list with scroll, so if:

- we swipe up (y axis, event.target is "the list"); as the scroll is yet 0, all good
- we scroll down the list...
- we swipe down (y axis, event.target is "the list"): here is when we do our check inside onTouchStart and the swipe would be prevented, e.g. `onTouchStart = (ev) => (SCROLL_TOP > 0 && ev.target.closest('#the-list-container'))`
- now we swipe down (y axis, event.target is "the header"): with the setState approach the swipe would be still disabled, but it's not the case with this short-circuit approach

Let me know if you would modify something or if you know of a better approach. 

Many thanks! 💛 