### PR TITLE
feat: Pin `@babel/runtime` to major

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -36,7 +36,12 @@ module.exports = {
       },
     ],
     '@babel/plugin-transform-object-assign',
-    '@babel/plugin-transform-runtime',
+    [
+      '@babel/plugin-transform-runtime',
+      {
+        version: '^7.0.0',
+      },
+    ],
   ],
   env: {
     coverage: {

--- a/packages/react-swipeable-views-core/package.json
+++ b/packages/react-swipeable-views-core/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/oliviertassinari/react-swipeable-views/issues"
   },
   "dependencies": {
-    "@babel/runtime": "7.0.0",
+    "@babel/runtime": "^7.0.0",
     "warning": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/react-swipeable-views-utils/package.json
+++ b/packages/react-swipeable-views-utils/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/oliviertassinari/react-swipeable-views/issues"
   },
   "dependencies": {
-    "@babel/runtime": "7.0.0",
+    "@babel/runtime": "^7.0.0",
     "fbjs": "^0.8.4",
     "keycode": "^2.1.7",
     "prop-types": "^15.6.0",

--- a/packages/react-swipeable-views/package.json
+++ b/packages/react-swipeable-views/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/oliviertassinari/react-swipeable-views/issues"
   },
   "dependencies": {
-    "@babel/runtime": "7.0.0",
+    "@babel/runtime": "^7.0.0",
     "dom-helpers": "^5.1.3",
     "prop-types": "^15.5.4",
     "react-swipeable-views-core": "^0.13.1",


### PR DESCRIPTION
We don't have to use the same version of `@babel/runtime` as `@babel/plugin-transform-runtime`. We can pin to whatever version we like as long as [`transform-runtime` is configured accordingly](https://babeljs.io/docs/en/babel-plugin-transform-runtime#version).