### PR TITLE
Use native event listeners instead of dom-heplers shims

### DIFF
--- a/packages/react-swipeable-views/package.json
+++ b/packages/react-swipeable-views/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0",
-    "dom-helpers": "^3.2.1",
     "prop-types": "^15.5.4",
     "react-swipeable-views-core": "^0.13.7",
     "react-swipeable-views-utils": "^0.13.7",

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';
-import transitionInfo from 'dom-helpers/transition/properties';
-import addEventListener from 'dom-helpers/events/on';
-import removeEventListener from 'dom-helpers/events/off';
 import {
   constant,
   checkIndexBounds,
@@ -11,11 +8,11 @@ import {
   getDisplaySameSlide,
 } from 'react-swipeable-views-core';
 
-function addEventListenerEnhanced(node, event, handler, options) {
-  addEventListener(node, event, handler, options);
+function addEventListener(node, event, handler, options) {
+  node.addEventListener(event, handler, options);
   return {
     remove() {
-      removeEventListener(node, event, handler, options);
+      node.removeEventListener(event, handler, options);
     },
   };
 }
@@ -264,20 +261,16 @@ class SwipeableViews extends React.Component {
 
   componentDidMount() {
     // Subscribe to transition end events.
-    this.transitionListener = addEventListenerEnhanced(
-      this.containerNode,
-      transitionInfo.end,
-      event => {
-        if (event.target !== this.containerNode) {
-          return;
-        }
+    this.transitionListener = addEventListener(this.containerNode, 'transitionend', event => {
+      if (event.target !== this.containerNode) {
+        return;
+      }
 
-        this.handleTransitionEnd();
-      },
-    );
+      this.handleTransitionEnd();
+    });
 
     // Block the thread to handle that event.
-    this.touchMoveListener = addEventListenerEnhanced(
+    this.touchMoveListener = addEventListener(
       this.rootNode,
       'touchmove',
       event => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

@oliviertassinari here is the patch without `dom-heplers`. 

I just use native events, based on:
1. [MUI `.browserlistrc` file](https://github.com/mui-org/material-ui/blob/012747e529bbbd0ea37e7dc26acda5e92fbe5ec1/.browserslistrc)
2. [`addEventListner` CanIUse support table](https://caniuse.com/#search=addeventlistener)
3. [CSS Transitions (incl. `transitionend` event) CanIUse support table](https://caniuse.com/#feat=css-transitions)

Does that work?

Closes #564