### PR TITLE
feat: use shallow-equal over fbjs

### DIFF
--- a/packages/react-swipeable-views-utils/package.json
+++ b/packages/react-swipeable-views-utils/package.json
@@ -16,11 +16,11 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0",
-    "fbjs": "^0.8.4",
     "keycode": "^2.1.7",
     "prop-types": "^15.6.0",
     "react-event-listener": "^0.6.0",
-    "react-swipeable-views-core": "^0.13.7"
+    "react-swipeable-views-core": "^0.13.7",
+    "shallow-equal": "^1.2.1"
   },
   "devDependencies": {
     "pkgfiles": "^2.3.2"

--- a/packages/react-swipeable-views-utils/src/autoPlay.js
+++ b/packages/react-swipeable-views-utils/src/autoPlay.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowEqual from 'fbjs/lib/shallowEqual';
+import { shallowEqualObjects } from 'shallow-equal';
 import EventListener from 'react-event-listener';
 import { mod } from 'react-swipeable-views-core';
 
@@ -31,7 +31,7 @@ export default function autoPlay(MyComponent) {
     }
 
     componentDidUpdate(prevProps) {
-      const shouldResetInterval = !shallowEqual(
+      const shouldResetInterval = !shallowEqualObjects(
         {
           index: prevProps.index,
           interval: prevProps.interval,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4811,7 +4811,7 @@ fastparse@^1.1.1:
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
   integrity sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=
 
-fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.16:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -9427,6 +9427,11 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
+
+shallow-equal@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
+  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Replaces [`fbjs/lib/shallowEqual`](https://www.npmjs.com/package/fbjs) with [`shallow-equal`#`shallowEqualObjects`](https://www.npmjs.com/package/shallow-equal).
`fbjs` is not intended for usage outside of facebook and pulls in outdated dependencies (e.g. `isomorphic-fetch`).

It doesn't use same-value equality as of yet (proposed in https://github.com/moroshko/shallow-equal/pull/17) but it seems like this isn't an issue here since we control what kind of values we compare.