### PR TITLE
Updated the React lifecycle functions that were deprecated in 16.3+

### DIFF
--- a/packages/react-swipeable-views-utils/src/autoPlay.js
+++ b/packages/react-swipeable-views-utils/src/autoPlay.js
@@ -20,17 +20,13 @@ export default function autoPlay(MyComponent) {
       this.startInterval();
     }
 
-    componentWillReceiveProps(nextProps) {
-      const { index } = nextProps;
-
-      if (typeof index === 'number' && index !== this.props.index) {
-        this.setState({
-          index,
-        });
-      }
-    }
-
     componentDidUpdate(prevProps) {
+      const { index } = this.props;
+      if (typeof index === 'number' && prevProps.index !== index) {
+        // eslint-disable-next-line react/no-did-update-set-state
+        this.setState({ index });
+      }
+
       const shouldResetInterval = !shallowEqualObjects(
         {
           index: prevProps.index,
@@ -38,7 +34,7 @@ export default function autoPlay(MyComponent) {
           autoplay: prevProps.autoplay,
         },
         {
-          index: this.props.index,
+          index,
           interval: this.props.interval,
           autoplay: this.props.autoplay,
         },

--- a/packages/react-swipeable-views-utils/src/bindKeyboard.js
+++ b/packages/react-swipeable-views-utils/src/bindKeyboard.js
@@ -37,10 +37,11 @@ export default function bindKeyboard(MyComponent) {
       });
     }
 
-    componentWillReceiveProps(nextProps) {
-      const { index } = nextProps;
+    componentDidUpdate(prevProps) {
+      const { index } = this.props;
 
-      if (typeof index === 'number' && index !== this.props.index) {
+      if (typeof index === 'number' && index !== prevProps.index) {
+        // eslint-disable-next-line react/no-did-update-set-state
         this.setState({
           index,
         });

--- a/packages/react-swipeable-views-utils/src/virtualize.js
+++ b/packages/react-swipeable-views-utils/src/virtualize.js
@@ -26,11 +26,11 @@ export default function virtualize(MyComponent) {
       this.setWindow(this.state.index);
     }
 
-    componentWillReceiveProps(nextProps) {
-      const { index } = nextProps;
+    componentDidUpdate(prevProps) {
+      const { index } = this.props;
 
-      if (typeof index === 'number' && index !== this.props.index) {
-        const indexDiff = index - this.props.index;
+      if (typeof index === 'number' && index !== prevProps.index) {
+        const indexDiff = index - prevProps.index;
         this.setIndex(index, this.state.indexContainer + indexDiff, indexDiff);
       }
     }

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -301,18 +301,19 @@ class SwipeableViews extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { index } = nextProps;
+  componentDidUpdate(prevProps) {
+    const { index } = this.props;
 
-    if (typeof index === 'number' && index !== this.props.index) {
+    if (typeof index === 'number' && index !== prevProps.index) {
       if (process.env.NODE_ENV !== 'production') {
-        checkIndexBounds(nextProps);
+        checkIndexBounds(this.props);
       }
 
       this.setIndexCurrent(index);
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
-        // If true, we are going to change the children. We shoudn't animate it.
-        displaySameSlide: getDisplaySameSlide(this.props, nextProps),
+        // If true, we are going to change the children. We shouldn't animate it.
+        displaySameSlide: getDisplaySameSlide(prevProps, this.props),
         indexLatest: index,
       });
     }

--- a/packages/react-swipeable-views/src/SwipeableViews.test.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.test.js
@@ -179,6 +179,10 @@ describe('SwipeableViews', () => {
         index: 1,
       });
 
+      // Added to solve an issue where enzyme doesn't trigger componentDidUpdate with setProps
+      // https://github.com/airbnb/enzyme/issues/34#issuecomment-515133794
+      wrapper.update();
+
       assert.include(
         wrapper
           .childAt(0)


### PR DESCRIPTION
It looks like most of the componentWillReceiveProps functions were safe to convert to componentDidUpdate with relevant changes (nextProps -> props, props -> prevProps, etc). 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
