### PR TITLE
fix: hasAttribute is not a function

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -128,7 +128,7 @@ export function getDomTreeShapes(element, rootNode) {
 
   while (element && element !== rootNode) {
     // We reach a Swipeable View, no need to look higher in the dom tree.
-    if (element.hasAttribute('data-swipeable')) {
+    if (typeof element.hasAttribute !== 'function' || element.hasAttribute('data-swipeable')) {
       break;
     }
 


### PR DESCRIPTION
Not sure why, but we get this error in the logs: `TypeError e.hasAttribute is not a function`
(multiple browsers and versions: chrome, FF, Edge...)
