### PR TITLE
Updated unsafe lifecycle methods

### DIFF
--- a/packages/react-swipeable-views-utils/src/autoPlay.js
+++ b/packages/react-swipeable-views-utils/src/autoPlay.js
@@ -20,7 +20,7 @@ export default function autoPlay(MyComponent) {
       this.startInterval();
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
       const { index } = nextProps;
 
       if (typeof index === 'number' && index !== this.props.index) {

--- a/packages/react-swipeable-views-utils/src/bindKeyboard.js
+++ b/packages/react-swipeable-views-utils/src/bindKeyboard.js
@@ -31,13 +31,13 @@ export default function bindKeyboard(MyComponent) {
 
     state = {};
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       this.setState({
         index: this.props.index || 0,
       });
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
       const { index } = nextProps;
 
       if (typeof index === 'number' && index !== this.props.index) {

--- a/packages/react-swipeable-views-utils/src/virtualize.js
+++ b/packages/react-swipeable-views-utils/src/virtualize.js
@@ -22,11 +22,11 @@ export default function virtualize(MyComponent) {
      */
     state = {};
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       this.setWindow(this.state.index);
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
       const { index } = nextProps;
 
       if (typeof index === 'number' && index !== this.props.index) {

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -301,7 +301,7 @@ class SwipeableViews extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { index } = nextProps;
 
     if (typeof index === 'number' && index !== this.props.index) {


### PR DESCRIPTION
Since React v17 will drop the legacy lifecycle methods, I just added the `UNSAFE_` prefix to methods like `componentWillMount` and `componentWillReceiveProps`.

[React Migration Plan](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path)
