### PR TITLE
[type] Move type definitions from DefinitelyTyped

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "size": "size-limit",
     "size:why": "size-limit --why packages/react-swipeable-views/lib/index.js",
     "watch": "lerna exec --concurrency 99 -- babel src --out-dir lib --watch",
-    "build": "rm -rf packages/*/lib && cross-env NODE_ENV=production lerna exec -- babel --config-file ../../babel.config.js src --out-dir lib --ignore test.js",
+    "build": "yarn prebuild && cross-env NODE_ENV=production lerna exec -- babel --config-file ../../babel.config.js src --out-dir lib --ignore test.js && yarn build:copy-files",
+    "prebuild": "rm -rf packages/*/lib",
+    "build:copy-files": "lerna exec node ../../scripts/copy-files.js",
     "release": "yarn build && yarn lerna exec yarn prepublish && lerna publish",
     "postrelease": "yarn docs:deploy"
   },

--- a/packages/react-swipeable-views-core/src/checkIndexBounds.d.ts
+++ b/packages/react-swipeable-views-core/src/checkIndexBounds.d.ts
@@ -1,0 +1,3 @@
+import { SwipeableViewsProps } from 'react-swipeable-views';
+
+export function checkIndexBounds(props: SwipeableViewsProps): void;

--- a/packages/react-swipeable-views-core/src/computeIndex.d.ts
+++ b/packages/react-swipeable-views-core/src/computeIndex.d.ts
@@ -1,0 +1,17 @@
+import { SwipeableViewsProps } from 'react-swipeable-views';
+
+export interface ComputeIndexParams {
+    children: SwipeableViewsProps['children'];
+    resistance: SwipeableViewsProps['resistance'];
+    startIndex: number;
+    startX: number;
+    pageX: number;
+    viewLength: number;
+}
+
+export function computeIndex(
+    params: ComputeIndexParams,
+): {
+    index: number;
+    startX: number;
+};

--- a/packages/react-swipeable-views-core/src/constant.d.ts
+++ b/packages/react-swipeable-views-core/src/constant.d.ts
@@ -1,0 +1,4 @@
+export const constant: {
+  RESISTANCE_COEF: number;
+  UNCERTAINTY_THRESHOLD: number;
+};

--- a/packages/react-swipeable-views-core/src/getDisplaySameSlide.d.ts
+++ b/packages/react-swipeable-views-core/src/getDisplaySameSlide.d.ts
@@ -1,0 +1,3 @@
+import { SwipeableViewsProps } from 'react-swipeable-views';
+
+export function getDisplaySameSlide(props: SwipeableViewsProps, nextProps: SwipeableViewsProps): boolean;

--- a/packages/react-swipeable-views-core/src/index.d.ts
+++ b/packages/react-swipeable-views-core/src/index.d.ts
@@ -1,0 +1,5 @@
+export { default as checkIndexBounds } from './checkIndexBounds';
+export { default as computeIndex } from './computeIndex';
+export { default as constant } from './constant';
+export { default as getDisplaySameSlide } from './getDisplaySameSlide';
+export { default as mod } from './mod';

--- a/packages/react-swipeable-views-core/src/mod.d.ts
+++ b/packages/react-swipeable-views-core/src/mod.d.ts
@@ -1,0 +1,1 @@
+export function mod(n: number, m: number): number;

--- a/packages/react-swipeable-views-utils/package.json
+++ b/packages/react-swipeable-views-utils/package.json
@@ -20,7 +20,8 @@
     "prop-types": "^15.6.0",
     "react-event-listener": "^0.6.0",
     "react-swipeable-views-core": "^0.13.7",
-    "shallow-equal": "^1.2.1"
+    "shallow-equal": "^1.2.1",
+    "@material-ui/types": "^4.0.0"
   },
   "devDependencies": {
     "pkgfiles": "^2.3.2"

--- a/packages/react-swipeable-views-utils/src/autoPlay.d.ts
+++ b/packages/react-swipeable-views-utils/src/autoPlay.d.ts
@@ -1,0 +1,17 @@
+import { OnChangeIndexCallback, OnSwitchingCallback } from 'react-swipeable-views';
+
+export interface WithAutoPlay {
+  index: number;
+  onChangeIndex: OnChangeIndexCallback;
+  onSwitching?: OnSwitchingCallback;
+}
+
+export interface WithAutoPlayProps {
+  autoplay?: boolean;
+  direction?: 'incremental' | 'decremental';
+  index: number;
+  interval?: number;
+  onChangeIndex: OnChangeIndexCallback;
+  slideCount?: number;
+}
+export const autoPlay: PropInjector<WithAutoPlay, WithAutoPlayProps>;

--- a/packages/react-swipeable-views-utils/src/autoPlay.d.ts
+++ b/packages/react-swipeable-views-utils/src/autoPlay.d.ts
@@ -1,4 +1,5 @@
 import { OnChangeIndexCallback, OnSwitchingCallback } from 'react-swipeable-views';
+import { PropInjector } from '@material-ui/types';
 
 export interface WithAutoPlay {
   index: number;

--- a/packages/react-swipeable-views-utils/src/bindKeyboard.d.ts
+++ b/packages/react-swipeable-views-utils/src/bindKeyboard.d.ts
@@ -1,3 +1,4 @@
+import { PropInjector } from '@material-ui/types';
 import { OnChangeIndexCallback } from 'react-swipeable-views';
 
 export interface WithBindKeyboard {

--- a/packages/react-swipeable-views-utils/src/bindKeyboard.d.ts
+++ b/packages/react-swipeable-views-utils/src/bindKeyboard.d.ts
@@ -1,0 +1,15 @@
+import { OnChangeIndexCallback } from 'react-swipeable-views';
+
+export interface WithBindKeyboard {
+  index: number;
+  onChangeIndex: OnChangeIndexCallback;
+}
+
+export interface WithBindKeyboardProps {
+  axis?: "x" | "x-reverse" | "y" | "y-reverse";
+  index: number;
+  onChangeIndex: OnChangeIndexCallback;
+  slidecount?: number;
+}
+
+export const bindKeyboard: PropInjector<WithBindKeyboard, WithBindKeyboardProps>;

--- a/packages/react-swipeable-views-utils/src/index.d.ts
+++ b/packages/react-swipeable-views-utils/src/index.d.ts
@@ -1,0 +1,3 @@
+export { default as autoPlay } from './autoPlay';
+export { default as bindKeyboard } from './bindKeyboard';
+export { default as virtualize } from './virtualize';

--- a/packages/react-swipeable-views-utils/src/virtualize.d.ts
+++ b/packages/react-swipeable-views-utils/src/virtualize.d.ts
@@ -1,0 +1,29 @@
+import { PropInjector } from '@material-ui/types';
+import * as React from 'react';
+import { OnChangeIndexCallback, OnTransitionEndCallback } from 'react-swipeable-views';
+
+export interface SlideRenderProps {
+  index: number;
+  key: number;
+}
+
+export type SlideRendererCallback = (render: SlideRenderProps) => React.ReactNode;
+
+export interface WithVirtualize {
+  index: number;
+  onChangeIndex: OnChangeIndexCallback;
+  slideRenderer: (render: SlideRendererCallback) => React.ReactNode;
+}
+
+export interface WithVirtualizeProps {
+  index: number;
+  onChangeIndex: OnChangeIndexCallback;
+  onTransitionEnd?: OnTransitionEndCallback;
+  overscanSlideAfter?: number;
+  overscanSlideBefore?: number;
+  slideCount?: number;
+  children?: React.ReactNode;
+  slideRenderer: SlideRendererCallback;
+}
+
+export const virtualize: PropInjector<WithVirtualize, WithVirtualizeProps>;

--- a/packages/react-swipeable-views/src/SwipeableViews.d.ts
+++ b/packages/react-swipeable-views/src/SwipeableViews.d.ts
@@ -19,6 +19,7 @@ export interface SpringConfig {
 export interface SwipeableViewsProps extends React.HTMLProps<HTMLDivElement> {
   animateHeight?: boolean;
   animateTransitions?: boolean;
+  action?: (hooks: SwipeableViewsHooks) => void;
   axis?: AxisType;
   containerStyle?: React.CSSProperties;
   disabled?: boolean;

--- a/packages/react-swipeable-views/src/SwipeableViews.d.ts
+++ b/packages/react-swipeable-views/src/SwipeableViews.d.ts
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+export type OnChangeIndexCallback = (index: number, indexLatest: number) => void;
+
+export type OnTransitionEndCallback = () => void;
+
+export type OnSwitchingCallback = (index: number, type: OnSwitchingCallbackTypeDescriptor) => void;
+
+export type OnSwitchingCallbackTypeDescriptor = 'move' | 'end';
+
+export type AxisType = 'x' | 'x-reverse' | 'y' | 'y-reverse';
+
+export interface SpringConfig {
+  duration: string;
+  easeFunction: string;
+  delay: string;
+}
+
+export interface SwipeableViewsProps extends React.HTMLProps<HTMLDivElement> {
+  animateHeight?: boolean;
+  animateTransitions?: boolean;
+  axis?: AxisType;
+  containerStyle?: React.CSSProperties;
+  disabled?: boolean;
+  /*
+   * This is the config used to disable lazy loading, if true it will render all the views in first rendering.
+   */
+  disableLazyLoading?: boolean;
+  enableMouseEvents?: boolean;
+  hysteresis?: number;
+  ignoreNativeScroll?: boolean;
+  index?: number;
+  onChangeIndex?: OnChangeIndexCallback;
+  onSwitching?: OnSwitchingCallback;
+  onTransitionEnd?: OnTransitionEndCallback;
+  resistance?: boolean;
+  style?: React.CSSProperties;
+  slideStyle?: React.CSSProperties;
+  springConfig?: SpringConfig;
+  slideClassName?: string;
+  threshold?: number;
+}
+
+export interface SwipeableViewsState {
+  indexCurrent?: number;
+  indexLatest?: number;
+  isDragging?: boolean;
+  isFirstRender?: boolean;
+  heightLatest?: number;
+  displaySameSlide?: boolean;
+}
+
+export default class SwipeableViews extends React.Component<
+  SwipeableViewsProps,
+  SwipeableViewsState,
+> {}

--- a/packages/react-swipeable-views/src/SwipeableViews.d.ts
+++ b/packages/react-swipeable-views/src/SwipeableViews.d.ts
@@ -19,7 +19,6 @@ export interface SpringConfig {
 export interface SwipeableViewsProps extends React.HTMLProps<HTMLDivElement> {
   animateHeight?: boolean;
   animateTransitions?: boolean;
-  action?: (hooks: SwipeableViewsHooks) => void;
   axis?: AxisType;
   containerStyle?: React.CSSProperties;
   disabled?: boolean;

--- a/packages/react-swipeable-views/src/index.d.ts
+++ b/packages/react-swipeable-views/src/index.d.ts
@@ -1,0 +1,2 @@
+export * from './SwipeableViews';
+export { default } from './SwipeableViews';

--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-console */
+const path = require('path');
+const fse = require('fs-extra');
+const glob = require('glob');
+
+const packagePath = process.cwd();
+const buildPath = path.join(packagePath, './lib');
+const srcPath = path.join(packagePath, './src');
+
+async function typescriptCopy({ from, to }) {
+  if (!(await fse.exists(to))) {
+    console.warn(`path ${to} does not exists`);
+    return [];
+  }
+
+  const files = glob.sync('**/*.d.ts', { cwd: from });
+  const cmds = files.map(file => fse.copy(path.resolve(from, file), path.resolve(to, file)));
+  return Promise.all(cmds);
+}
+
+async function run() {
+  try {
+    // TypeScript
+    await typescriptCopy({ from: srcPath, to: buildPath });
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+run();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,6 +1640,13 @@
     "@babel/runtime" "7.0.0"
     recompose "^0.29.0"
 
+"@material-ui/types@^4.0.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-4.1.1.tgz#b65e002d926089970a3271213a3ad7a21b17f02b"
+  integrity sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==
+  dependencies:
+    "@types/react" "*"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
moved type definition from 
- [types/react-swipeable-views](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-swipeable-views)
- [types/react-swipeable-views-utils](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-swipeable-views-utils)
- [types/react-swipeable-views-core](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-swipeable-views-core)

Closes #506

i just moved, but type could be updated for instance, `getDomTreeShapes` and `findNativeHandler` are exported from `SwipeableViews.js` but not defined on DefinitelyTyped.
i didn't fix because i'm wondering theses should be exported 

---
adding type test