### PR TITLE
Fix scrollTop is not always be an integer

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -179,7 +179,9 @@ export function findNativeHandler(params) {
       goingForward = !goingForward;
     }
 
-    const scrollPosition = shape[axisProperties.scrollPosition[axis]];
+    // scrollTop is not always be an integer.
+    // https://github.com/jquery/api.jquery.com/issues/608
+    const scrollPosition = Math.round(shape[axisProperties.scrollPosition[axis]]);
 
     const areNotAtStart = scrollPosition > 0;
     const areNotAtEnd =


### PR DESCRIPTION
On some browsers, I have scrolled to the bottom, but the calculated "areNotAtEnd" value is true, so I can't continue to swipe next.
https://github.com/jquery/api.jquery.com/issues/608

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
