### PR TITLE
Rename api action to actionCallbacks

### DIFF
--- a/docs/src/pages/api/api.md
+++ b/docs/src/pages/api/api.md
@@ -6,7 +6,7 @@
 
 | Name | Type | Default | Platform | Description |
 |:-----|:-----|:--------|:---------|:------------|
-| action | function(hooks) |  | browser | This is callback property. It's called by the component on mount. This is useful when you want to trigger an action programmatically. It currently only supports updateHeight() action. |
+| actionCallbacks | function(hooks) |  | browser | This is callback property. It's called by the component on mount. This is useful when you want to trigger an action programmatically. It currently only supports updateHeight() action. |
 | animateHeight | bool | `false` | browser | If `true`, the height of the container will be animated to match the current slide height. Animating another style property has a negative impact regarding performance. |
 | animateTransitions | bool | `true` | all | If `false`, changes to the index prop will not cause an animated transition. |
 | axis | enum [`'x'`, `'x-reverse'`, `'y'`, `'y-reverse'`] | `'x'` | browser | The axis on which the slides will slide. |

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -293,9 +293,9 @@ class SwipeableViews extends React.Component {
       }, 0);
     }
 
-    // Send all functions in an object if action param is set.
-    if (this.props.action) {
-      this.props.action({
+    // Send all functions in an object if actionCallbacks param is set.
+    if (this.props.actionCallbacks) {
+      this.props.actionCallbacks({
         updateHeight: this.updateHeight,
       });
     }
@@ -688,7 +688,6 @@ class SwipeableViews extends React.Component {
 
   render() {
     const {
-      action,
       animateHeight,
       animateTransitions,
       axis,
@@ -848,10 +847,10 @@ SwipeableViews.propTypes = {
    * This is useful when you want to trigger an action programmatically.
    * It currently only supports updateHeight() action.
    *
-   * @param {object} actions This object contains all posible actions
+   * @param {object} actionCallbacks This object contains all posible actions
    * that can be triggered programmatically.
    */
-  action: PropTypes.func,
+  actionCallbacks: PropTypes.func,
   /**
    * If `true`, the height of the container will be animated to match the current slide height.
    * Animating another style property has a negative impact regarding performance.

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -688,6 +688,7 @@ class SwipeableViews extends React.Component {
 
   render() {
     const {
+      actionCallbacks,
       animateHeight,
       animateTransitions,
       axis,

--- a/packages/react-swipeable-views/src/SwipeableViews.test.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.test.js
@@ -661,12 +661,12 @@ describe('SwipeableViews', () => {
     });
   });
 
-  describe('prop: action', () => {
+  describe('prop: actionCallbacks', () => {
     it('should be able to access updateHeight function', () => {
       let swipeableActions = {};
       mount(
         <SwipeableViews
-          action={actions => {
+          actionCallbacks={actions => {
             swipeableActions = actions;
           }}
         >


### PR DESCRIPTION
## Breaking Change

```diff
- <SwipeableViews action={} >
+ <SwipeableViews actionCallbacks={} >
```

Fixes #615

TODO:
when this change is merged and released, we need to fix type definition on DefinetlyTyped.