### PR TITLE
Removed UNSAFE from SwipeableWiews

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -302,18 +302,19 @@ class SwipeableViews extends React.Component {
   }
 
   // eslint-disable-next-line camelcase,react/sort-comp
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const { index } = nextProps;
+  componentDidUpdate(prevProps) {
+    const { index } = this.props;
 
-    if (typeof index === 'number' && index !== this.props.index) {
+    if (typeof index === 'number' && index !== prevProps.index) {
       if (process.env.NODE_ENV !== 'production') {
-        checkIndexBounds(nextProps);
+        checkIndexBounds(this.props);
       }
 
       this.setIndexCurrent(index);
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
         // If true, we are going to change the children. We shoudn't animate it.
-        displaySameSlide: getDisplaySameSlide(this.props, nextProps),
+        displaySameSlide: getDisplaySameSlide(prevProps, this.props),
         indexLatest: index,
       });
     }

--- a/packages/react-swipeable-views/src/SwipeableViews.test.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.test.js
@@ -179,6 +179,8 @@ describe('SwipeableViews', () => {
         index: 1,
       });
 
+      wrapper.setState({});
+
       assert.include(
         wrapper
           .childAt(0)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


- Legacy component lifecycles[ will get deprecated](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) because they have too many potential pitfalls to be safely used for the newly implemented async rendering.


This PR replaces `UNSAFE_componentWillReceiveProps` from SwipeableViews.js with `componentDidUpdate`. `componentDidUpdate` gets triggered on each props and state change; therefore a conditional is needed to make sure `setState` methods are controlled and don't cause infinite loops. In this case, `this.props.index !== prevProps.index` is the conditional that controls the logic inside `componentDidUpdate`.