### PR TITLE
Fix throw error when using a portal inside a view

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -126,7 +126,7 @@ function adaptMouse(event) {
 export function getDomTreeShapes(element, rootNode) {
   let domTreeShapes = [];
 
-  while (element && element !== rootNode) {
+  while (element && element !== rootNode && element !== document.body) {
     // We reach a Swipeable View, no need to look higher in the dom tree.
     if (element.hasAttribute('data-swipeable')) {
       break;


### PR DESCRIPTION
Repro:
- Put a portal inside a swipeable view
- click & drag something in the portal
- watch the `while` loop propagate up to the `html` tag & bork the app because `html.hasAttribute` isn't a function

Closes #589