### PR TITLE
Adjust react version in peerDependencies

### DIFF
--- a/packages/react-swipeable-views/package.json
+++ b/packages/react-swipeable-views/package.json
@@ -28,7 +28,7 @@
     "warning": "^4.0.1"
   },
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0"
+    "react": ">=15.3.0"
   },
   "devDependencies": {
     "pkgfiles": "^2.3.2"

--- a/packages/react-swipeable-views/package.json
+++ b/packages/react-swipeable-views/package.json
@@ -28,7 +28,7 @@
     "warning": "^4.0.1"
   },
   "peerDependencies": {
-    "react": ">=15.3.0"
+    "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "pkgfiles": "^2.3.2"


### PR DESCRIPTION
This PR addresses the version issue when using react-swipeable-views in a project with `"react": "^17.0.1"` as dependency and running `npm install`:

```
npm ERR! Found: react@17.0.1
npm ERR! node_modules/react
npm ERR!   react@"^17.0.1" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^15.3.0 || ^16.0.0" from react-swipeable-views@0.14.0-alpha.0
npm ERR! node_modules/react-swipeable-views
npm ERR!   react-swipeable-views@"^0.14.0-alpha.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

Reproducible with Node.js `v14.16.0` and npm `v7.6.1`.