### PR TITLE
feat: add `moveRate` prop

### DIFF
--- a/docs/src/pages/api/api.md
+++ b/docs/src/pages/api/api.md
@@ -28,6 +28,7 @@
 | springConfig | object | `{duration: '0.3s', easeFunction: '...', delay: '0s'}` | browser | This is the config used to create CSS transitions. This is useful to change the dynamic of the transition. |
 | springConfig | object | `{tension: 300, friction: 30}` | native.animated | This is the config given to Animated for the `spring`. This is useful to change the dynamic of the transition. |
 | threshold | integer | `5` | all | This is the threshold used for detecting a quick swipe. If the computed speed is above this value, the index change. |
+| moveRate | float | `1` | all | Control the move speed when swiping. |
 
 Any other properties like `className` will be applied to the root component.
 

--- a/packages/react-swipeable-views-core/src/computeIndex.js
+++ b/packages/react-swipeable-views-core/src/computeIndex.js
@@ -2,10 +2,10 @@ import React from 'react';
 import constant from './constant';
 
 export default function computeIndex(params) {
-  const { children, startIndex, startX, pageX, viewLength, resistance } = params;
+  const { children, startIndex, startX, pageX, viewLength, resistance, moveRate } = params;
 
   const indexMax = React.Children.count(children) - 1;
-  let index = startIndex + (startX - pageX) / viewLength;
+  let index = startIndex + ((startX - pageX) / viewLength) * (moveRate || 1);
   let newStartX;
 
   if (!resistance) {

--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -413,7 +413,7 @@ class SwipeableViews extends React.Component {
       return;
     }
 
-    const { axis, children, ignoreNativeScroll, onSwitching, resistance } = this.props;
+    const { axis, children, ignoreNativeScroll, onSwitching, resistance, moveRate } = this.props;
     const touch = applyRotationMatrix(event.touches[0], axis);
 
     // We don't know yet.
@@ -466,6 +466,7 @@ class SwipeableViews extends React.Component {
       startIndex: this.startIndex,
       startX: this.startX,
       viewLength: this.viewLength,
+      moveRate,
     });
 
     // Add support for native scroll elements.
@@ -715,6 +716,7 @@ class SwipeableViews extends React.Component {
       springConfig,
       style,
       threshold,
+      moveRate,
       ...other
     } = this.props;
 


### PR DESCRIPTION
When custom width of slides, the movement speed become slower than the mouse/touch move.

It would be useful if add a prop to adjust the speed when move the slides