### PR TITLE
fixed UNSAFE_componentWillReceiveProps error

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -253,6 +253,7 @@ class SwipeableViews extends React.Component {
       heightLatest: 0,
       // Let the render method that we are going to display the same slide than previously.
       displaySameSlide: true,
+      setIndexCurrent: this.setIndexCurrent.bind(this),
     };
     this.setIndexCurrent(props.index);
   }
@@ -299,28 +300,38 @@ class SwipeableViews extends React.Component {
     }
   }
 
-  // eslint-disable-next-line camelcase,react/sort-comp
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const { index } = nextProps;
-
-    if (typeof index === 'number' && index !== this.props.index) {
-      if (process.env.NODE_ENV !== 'production') {
-        checkIndexBounds(nextProps);
-      }
-
-      this.setIndexCurrent(index);
-      this.setState({
-        // If true, we are going to change the children. We shoudn't animate it.
-        displaySameSlide: getDisplaySameSlide(this.props, nextProps),
-        indexLatest: index,
-      });
-    }
-  }
-
   componentWillUnmount() {
     this.transitionListener.remove();
     this.touchMoveListener.remove();
     clearTimeout(this.firstRenderTimeout);
+    this.setState();
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const { index } = nextProps;
+
+    if (typeof index === 'number' && index !== prevState.index) {
+      if (process.env.NODE_ENV !== 'production') {
+        checkIndexBounds(nextProps);
+      }
+
+      if (!prevState.children) {
+        prevState = { ...prevState, children: [] };
+      }
+
+      return {
+        ...nextProps,
+        displaySameSlide: getDisplaySameSlide(prevState, nextProps),
+        indexLatest: index,
+        model: prevState.setIndexCurrent(index),
+      };
+    }
+
+    return {
+      ...nextProps,
+      indexLatest: index,
+      setIndexCurrent: prevState.setIndexCurrent,
+    };
   }
 
   getSwipeableViewsContext() {


### PR DESCRIPTION
Replaced ‘UNSAFE_componentWillReceiveProps’ with ‘static getDerivedStateFromProps’ 

**Address the following error:**
```
Warning: Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code. See https://reactjs.org/link/unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://reactjs.org/link/derived-state

Please update the following components: ReactSwipableView
```

Might also be related to: #534