### PR TITLE
Use caret range for @babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-react": "7.0.0",
     "@babel/preset-stage-1": "7.0.0",
     "@babel/register": "7.0.0",
-    "@babel/runtime": "7.0.0",
+    "@babel/runtime": "^7.0.0",
     "@material-ui/core": "^3.0.0",
     "@material-ui/docs": "^1.0.0-alpha.3",
     "@material-ui/icons": "^3.0.0",

--- a/packages/react-swipeable-views-core/package.json
+++ b/packages/react-swipeable-views-core/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/oliviertassinari/react-swipeable-views/issues"
   },
   "dependencies": {
-    "@babel/runtime": "7.0.0",
+    "@babel/runtime": "^7.0.0",
     "warning": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/react-swipeable-views-utils/package.json
+++ b/packages/react-swipeable-views-utils/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/oliviertassinari/react-swipeable-views/issues"
   },
   "dependencies": {
-    "@babel/runtime": "7.0.0",
+    "@babel/runtime": "^7.0.0",
     "keycode": "^2.1.7",
     "prop-types": "^15.6.0",
     "react-event-listener": "^0.6.0",

--- a/packages/react-swipeable-views/package.json
+++ b/packages/react-swipeable-views/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/oliviertassinari/react-swipeable-views/issues"
   },
   "dependencies": {
-    "@babel/runtime": "7.0.0",
+    "@babel/runtime": "^7.0.0",
     "prop-types": "^15.5.4",
     "react-swipeable-views-core": "^0.14.1",
     "react-swipeable-views-utils": "^0.14.1",


### PR DESCRIPTION
The published packages declare `@babel/runtime` as an exact `7.0.0` dependency. This prevents package managers from deduplicating it against a newer `7.x` copy already present in a consumer's tree, forcing a duplicate install.

Switching the pin to `^7.0.0` lets any compatible `7.x` satisfy the constraint, so it can be deduped.

See also https://github.com/mui/material-ui/pull/48710